### PR TITLE
Code improvements.

### DIFF
--- a/pipeline.sh
+++ b/pipeline.sh
@@ -26,8 +26,8 @@ INPUT_PED=""
 INPUT_PHENO=""
 OUTPUT=""
 ANN_VEP=""
-FORCE=""
-KEEP=""
+FORCE=0
+KEEP=0
 ASSEMBLY=GRCh37
 CPU_CORES=4
 
@@ -69,79 +69,67 @@ while :
 do
   case "$1" in
     -i | --input)
-        INPUT=$(realpath "$2")
-        shift 2
-        ;;
+      INPUT=$(realpath "$2")
+      shift 2
+      ;;
     -o | --output)
-        OUTPUT_ARG="$2"
-        OUTPUT_DIR_RELATIVE=$(dirname "$OUTPUT_ARG")
-        OUTPUT_DIR_ABSOLUTE=$(realpath "$OUTPUT_DIR_RELATIVE")
-        OUTPUT_FILE=$(basename "$OUTPUT_ARG")
-        OUTPUT="${OUTPUT_DIR_ABSOLUTE}"/"${OUTPUT_FILE}"
-        shift 2
-        ;;
+      OUTPUT_ARG="$2"
+      OUTPUT_DIR_RELATIVE=$(dirname "$OUTPUT_ARG")
+      OUTPUT_DIR_ABSOLUTE=$(realpath "$OUTPUT_DIR_RELATIVE")
+      OUTPUT_FILE=$(basename "$OUTPUT_ARG")
+      OUTPUT="${OUTPUT_DIR_ABSOLUTE}"/"${OUTPUT_FILE}"
+      shift 2
+      ;;
     -r | --reference)
-        INPUT_REF=$(realpath "$2")
-        shift 2
-        ;;
+      INPUT_REF=$(realpath "$2")
+      shift 2
+      ;;
     -p | --pedigree)
-        INPUT_PED=$(realpath "$2")
-        shift 2
-        ;;
+      INPUT_PED=$(realpath "$2")
+      shift 2
+      ;;
     -t | --phenotypes)
-        INPUT_PHENO="$2"
-        shift 2
-        ;;
+      INPUT_PHENO="$2"
+      shift 2
+      ;;
     --ann_vep)
-        ANN_VEP="$2"
-        shift 2
-        ;;
+      ANN_VEP="$2"
+      shift 2
+      ;;
     -f | --force)
-        FORCE=1
-        shift
-        ;;
+      FORCE=1
+      shift
+      ;;
     -k | --keep)
-        KEEP=1
-        shift
-        ;;
+      KEEP=1
+      shift
+      ;;
     --)
-        shift
-        break
-        ;;
+      shift
+      break
+      ;;
     *)
-        usage
-	exit 2
-        ;;
+      usage
+	    exit 2
+      ;;
   esac
 done
 
-if [ -z ${INPUT} ]
+if [ -z "${INPUT}" ]
 then
-        echo "missing required option -i
-	"
+  echo -e "missing required option -i\n"
 	usage
 	exit 2
 fi
-if [ -z ${OUTPUT} ]
+if [ -z "${OUTPUT}" ]
 then
-        echo "missing required option -o
-	"
+  echo -e "missing required option -o\n"
 	usage
 	exit 2
 fi
-if [ -z ${FORCE} ]
-then
-	FORCE=0
-fi
-if [ -z ${KEEP} ]
-then
-        KEEP=0
-fi
-
 if [ ! -f "${INPUT}" ]
 then
-	echo "$INPUT does not exist.
-	"
+	echo -e "$INPUT does not exist.\n"
 	exit 2
 fi
 if [ -f "${OUTPUT}" ]
@@ -150,58 +138,48 @@ then
 	then
 		rm "${OUTPUT}"
 	else
-		echo "${OUTPUT} already exists, use -f to overwrite.
-        	"
-	        exit 2
+		echo -e "${OUTPUT} already exists, use -f to overwrite.\n"
+    exit 2
 	fi
 fi
 if [ -f "${OUTPUT}".html ]
 then
-        if [ "${FORCE}" == "1" ]
-        then
-                rm "${OUTPUT}".html
-        else
-                echo "${OUTPUT}.html already exists, use -f to overwrite.
-                "
-                exit 2
-        fi
+  if [ "${FORCE}" == "1" ]
+  then
+    rm "${OUTPUT}".html
+  else
+    echo -e "${OUTPUT}.html already exists, use -f to overwrite.\n"
+    exit 2
+  fi
 fi
-if [ ! -z ${INPUT_PED} ]
+if [ ! -z ${INPUT_PED} ] && [ ! -f "${INPUT_PED}" ]
 then
-		if [ ! -f "${INPUT_PED}" ]
-		then
-			echo "${INPUT_PED} does not exist.
-			"
-			exit 2
-		fi
+  echo -e "${INPUT_PED} does not exist.\n"
+  exit 2
 fi
-if [ ! -z ${INPUT_REF} ]
+if [ ! -z ${INPUT_REF} ] && [ ! -f "${INPUT_REF}" ]
 then
-                if [ ! -f "${INPUT_REF}" ]
-                then
-                        echo "${INPUT_REF} does not exist.
-                        "
-                        exit 2
-                fi
+  echo -e "${INPUT_REF} does not exist.\n"
+  exit 2
 fi
 
 if [[ "${OUTPUT}" == *.vcf.gz ]]
-  then
-      OUTPUT_FILENAME=$(basename "${OUTPUT}" .vcf.gz)
-  else
-      OUTPUT_FILENAME=$(basename "${OUTPUT}" .vcf)
+then
+  OUTPUT_FILENAME=$(basename "${OUTPUT}" .vcf.gz)
+else
+  OUTPUT_FILENAME=$(basename "${OUTPUT}" .vcf)
 fi
 OUTPUT_DIR="${OUTPUT_DIR_ABSOLUTE}"/${OUTPUT_FILENAME}_pipeline_out
 
 if [ -d "$OUTPUT_DIR" ]
 then
-        if [ "$FORCE" == "1" ]
-        then
-                rm -R "$OUTPUT_DIR"
-        else
-                echo "$OUTPUT_DIR already exists, use -f to overwrite."
-                exit 2
-        fi
+  if [ "$FORCE" == "1" ]
+  then
+    rm -R "$OUTPUT_DIR"
+  else
+    echo -e "$OUTPUT_DIR already exists, use -f to overwrite.\n"
+    exit 2
+  fi
 fi
 
 mkdir -p "${OUTPUT_DIR}"
@@ -219,7 +197,7 @@ PREPROCESS_ARGS="\
 if [ ! -z "${INPUT_REF}" ]; then
 	PREPROCESS_ARGS+=" -r ${INPUT_REF}"
 fi
-if [ ! -z "${FORCE}" ]; then
+if [ "${FORCE}" == "1" ]; then
 	PREPROCESS_ARGS+=" -f"
 fi
 sh "${SCRIPT_DIR}"/pipeline_preprocess.sh ${PREPROCESS_ARGS}
@@ -239,10 +217,10 @@ ANNOTATE_ARGS="\
 if [ ! -z "${INPUT_REF}" ]; then
 	ANNOTATE_ARGS+=" -r ${INPUT_REF}"
 fi
-if [ ! -z "${KEEP}" ]; then
+if [ "${KEEP}" == "1" ]; then
 	ANNOTATE_ARGS+=" -k"
 fi
-if [ ! -z "${FORCE}" ]; then
+if [ "${FORCE}" == "1" ]; then
 	ANNOTATE_ARGS+=" -f"
 fi
 
@@ -264,7 +242,7 @@ FILTER_ARGS="\
   -i ${ANNOTATE_OUTPUT}\
   -o ${FILTER_OUTPUT} \
   -c ${CPU_CORES}"
-if [ ! -z "${FORCE}" ]; then
+if [ "${FORCE}" == "1" ]; then
 	FILTER_ARGS+=" -f"
 fi
 sh "${SCRIPT_DIR}"/pipeline_filter.sh ${FILTER_ARGS}
@@ -288,7 +266,7 @@ fi
 if [ ! -z "${INPUT_PHENO}" ]; then
 	REPORT_ARGS+=" -t ${INPUT_PHENO}"
 fi
-if [ ! -z "${FORCE}" ]; then
+if [ "${FORCE}" == "1" ]; then
 	REPORT_ARGS+=" -f"
 fi
 sh "${SCRIPT_DIR}"/pipeline_report.sh ${REPORT_ARGS}

--- a/pipeline_annotate.sh
+++ b/pipeline_annotate.sh
@@ -23,11 +23,11 @@ source "${SCRIPT_DIR}"/utils/header.sh
 INPUT=""
 OUTPUT=""
 INPUT_REF=""
-ASSEMBLY=""
+ASSEMBLY=GRCh37
 ANN_VEP=""
-CPU_CORES=""
-FORCE=""
-KEEP=""
+CPU_CORES=4
+FORCE=0
+KEEP=0
 
 usage()
 {
@@ -63,87 +63,68 @@ while :
 do
   case "$1" in
     -i | --input)
-        INPUT=$(realpath "$2")
-        shift 2
-        ;;
+      INPUT=$(realpath "$2")
+      shift 2
+      ;;
     -o | --output)
-        OUTPUT_ARG="$2"
-        OUTPUT_DIR_RELATIVE=$(dirname "$OUTPUT_ARG")
-        OUTPUT_DIR_ABSOLUTE=$(realpath "$OUTPUT_DIR_RELATIVE")
-        OUTPUT_FILE=$(basename "$OUTPUT_ARG")
-        OUTPUT="${OUTPUT_DIR_ABSOLUTE}"/"${OUTPUT_FILE}"
-        shift 2
-        ;;
+      OUTPUT_ARG="$2"
+      OUTPUT_DIR_RELATIVE=$(dirname "$OUTPUT_ARG")
+      OUTPUT_DIR_ABSOLUTE=$(realpath "$OUTPUT_DIR_RELATIVE")
+      OUTPUT_FILE=$(basename "$OUTPUT_ARG")
+      OUTPUT="${OUTPUT_DIR_ABSOLUTE}"/"${OUTPUT_FILE}"
+      shift 2
+      ;;
     -r | --reference)
-        INPUT_REF=$(realpath "$2")
-        shift 2
-        ;;
+      INPUT_REF=$(realpath "$2")
+      shift 2
+      ;;
     -c | --cpu_cores)
-        CPU_CORES="$2"
-        shift 2
-        ;;
+      CPU_CORES="$2"
+      shift 2
+      ;;
     -a | --assembly)
-        ASSEMBLY="$2"
-        shift 2
-        ;;
+      ASSEMBLY="$2"
+      shift 2
+      ;;
     --ann_vep)
-        ANN_VEP="$2"
-        shift 2
-        ;;
+      ANN_VEP="$2"
+      shift 2
+      ;;
     -f | --force)
-        FORCE=1
-        shift
-        ;;
+      FORCE=1
+      shift
+      ;;
     -k | --keep)
-        KEEP=1
-        shift
-        ;;
+      KEEP=1
+      shift
+      ;;
     --)
-        shift
-        break
-        ;;
+      shift
+      break
+      ;;
     *)
-        usage
-	exit 2
-        ;;
+      usage
+	    exit 2
+      ;;
   esac
 done
 
-if [ -z ${INPUT} ]
+if [ -z "${INPUT}" ]
 then
-        echo "missing required option -i
-	"
+  echo -e "missing required option -i\n"
 	usage
 	exit 2
 fi
-if [ -z ${OUTPUT} ]
+if [ -z "${OUTPUT}" ]
 then
-        echo "missing required option -o
-	"
+  echo -e "missing required option -o\n"
 	usage
 	exit 2
-fi
-if [ -z ${ASSEMBLY} ]
-then
-	ASSEMBLY=GRCh37
-fi
-if [ -z ${CPU_CORES} ]
-then
-	CPU_CORES=4
-fi
-if [ -z ${FORCE} ]
-then
-	FORCE=0
-fi
-if [ -z ${KEEP} ]
-then
-        KEEP=0
 fi
 
 if [ ! -f "${INPUT}" ]
 then
-	echo "$INPUT does not exist.
-	"
+	echo -e "$INPUT does not exist.\n"
 	exit 2
 fi
 if [ -f "${OUTPUT}" ]
@@ -152,23 +133,21 @@ then
 	then
 		rm "${OUTPUT}"
 	else
-		echo "${OUTPUT} already exists, use -f to overwrite.
-        	"
-	        exit 2
+		echo -e "${OUTPUT} already exists, use -f to overwrite.\n"
+    exit 2
 	fi
 fi
 if [ ! -z "${INPUT_REF}" ]
 then
-                if [ ! -f "${INPUT_REF}" ]
-                then
-                        echo "${INPUT_REF} does not exist.
-                        "
-                        exit 2
-                fi
+  if [ ! -f "${INPUT_REF}" ]
+  then
+    echo -e "${INPUT_REF} does not exist.\n"
+    exit 2
+  fi
 fi
 
 
-if [ -z ${TMPDIR+x} ]; then
+if [ -z "${TMPDIR+x}" ]; then
 	TMPDIR=/tmp
 fi
 
@@ -218,9 +197,9 @@ VCFANNO_POST_CONF="${CAPICE_OUTPUT_DIR}"/conf_post.toml
 
 if [[ "${OUTPUT_FILE}" == *vcf ]]
 then
-    CAPICE_OUTPUT="${CAPICE_OUTPUT_DIR}"/"${OUTPUT_FILE/.vcf/.tsv}"
+  CAPICE_OUTPUT="${CAPICE_OUTPUT_DIR}"/"${OUTPUT_FILE/.vcf/.tsv}"
 else
-    CAPICE_OUTPUT="${CAPICE_OUTPUT_DIR}"/"${OUTPUT_FILE/.vcf.gz/.tsv}"
+  CAPICE_OUTPUT="${CAPICE_OUTPUT_DIR}"/"${OUTPUT_FILE/.vcf.gz/.tsv}"
 fi
 CAPICE_OUTPUT_VCF="${CAPICE_OUTPUT_DIR}"/vcfanno_bcftools_filter_capice.vcf.gz
 
@@ -250,7 +229,7 @@ else
 	python ${EBROOTCAPICE}/CAPICE_scripts/model_inference.py \
 	--input_path ${CAPICE_OUTPUT_DIR}/cadd.tsv.gz \
 	--model_path ${EBROOTCAPICE}/CAPICE_model/${ASSEMBLY}/xgb_booster.pickle.dat \
-	--prediction_savepath ${CAPICE_OUTPUT} \
+	--prediction_savepath ${CAPICE_OUTPUT}
 
 	CAPICE_ARGS="\
 	-Djava.io.tmpdir="${TMPDIR}" \
@@ -334,7 +313,7 @@ mv "${VEP_OUTPUT}" "${OUTPUT}"
 ln -s "${OUTPUT}" "${VEP_OUTPUT}"
 
 if [ "$KEEP" == "0" ]; then
-        rm -rf "${VEP_OUTPUT_DIR}"
-        rm -rf "${CAPICE_OUTPUT_DIR}"
-        rm -rf "${VCFANNO_OUTPUT_DIR}"
+  rm -rf "${VEP_OUTPUT_DIR}"
+  rm -rf "${CAPICE_OUTPUT_DIR}"
+  rm -rf "${VCFANNO_OUTPUT_DIR}"
 fi

--- a/pipeline_filter.sh
+++ b/pipeline_filter.sh
@@ -22,8 +22,8 @@ source "${SCRIPT_DIR}"/utils/header.sh
 
 INPUT=""
 OUTPUT=""
-CPU_CORES=""
-FORCE=""
+CPU_CORES=4
+FORCE=0
 
 usage()
 {
@@ -51,63 +51,52 @@ while :
 do
   case "$1" in
     -i | --input)
-        INPUT=$(realpath "$2")
-        shift 2
-        ;;
+      INPUT=$(realpath "$2")
+      shift 2
+      ;;
     -o | --output)
-        OUTPUT_ARG="$2"
-        OUTPUT_DIR_RELATIVE=$(dirname "$OUTPUT_ARG")
-        OUTPUT_DIR_ABSOLUTE=$(realpath "$OUTPUT_DIR_RELATIVE")
-        OUTPUT_FILE=$(basename "$OUTPUT_ARG")
-        OUTPUT="${OUTPUT_DIR_ABSOLUTE}"/"${OUTPUT_FILE}"
-        shift 2
-        ;;
+      OUTPUT_ARG="$2"
+      OUTPUT_DIR_RELATIVE=$(dirname "$OUTPUT_ARG")
+      OUTPUT_DIR_ABSOLUTE=$(realpath "$OUTPUT_DIR_RELATIVE")
+      OUTPUT_FILE=$(basename "$OUTPUT_ARG")
+      OUTPUT="${OUTPUT_DIR_ABSOLUTE}"/"${OUTPUT_FILE}"
+      shift 2
+      ;;
     -c | --cpu_cores)
-        CPU_CORES="$2"
-        shift 2
-        ;;		
+      CPU_CORES="$2"
+      shift 2
+      ;;
     -f | --force)
-        FORCE=1
-        shift
-        ;;
+      FORCE=1
+      shift
+      ;;
     --)
-        shift
-        break
-        ;;
+      shift
+      break
+      ;;
     *)
-        usage
-	exit 2
-        ;;
+      usage
+	    exit 2
+      ;;
   esac
 done
 
-if [ -z ${INPUT} ]
+if [ -z "${INPUT}" ]
 then
-        echo "missing required option -i
-	"
+  echo -e "missing required option -i\n"
 	usage
 	exit 2
 fi
-if [ -z ${OUTPUT} ]
+if [ -z "${OUTPUT}" ]
 then
-        echo "missing required option -o
-	"
+  echo -e "missing required option -o\n"
 	usage
 	exit 2
-fi
-if [ -z ${CPU_CORES} ]
-then
-	CPU_CORES=4
-fi
-if [ -z ${FORCE} ]
-then
-	FORCE=0
 fi
 
 if [ ! -f "${INPUT}" ]
 then
-	echo "$INPUT does not exist.
-	"
+	echo -e "$INPUT does not exist.\n"
 	exit 2
 fi
 if [ -f "${OUTPUT}" ]
@@ -116,9 +105,8 @@ then
 	then
 		rm "${OUTPUT}"
 	else
-		echo "${OUTPUT} already exists, use -f to overwrite.
-        	"
-	        exit 2
+		echo -e "${OUTPUT} already exists, use -f to overwrite.\n"
+    exit 2
 	fi
 fi
 

--- a/pipeline_preprocess.sh
+++ b/pipeline_preprocess.sh
@@ -23,8 +23,8 @@ source "${SCRIPT_DIR}"/utils/header.sh
 INPUT=""
 INPUT_REF=""
 OUTPUT=""
-CPU_CORES=""
-FORCE=""
+CPU_CORES=4
+FORCE=0
 
 usage()
 {
@@ -54,67 +54,56 @@ while :
 do
   case "$1" in
     -i | --input)
-        INPUT=$(realpath "$2")
-        shift 2
-        ;;
+      INPUT=$(realpath "$2")
+      shift 2
+      ;;
     -o | --output)
-        OUTPUT_ARG="$2"
-        OUTPUT_DIR_RELATIVE=$(dirname "$OUTPUT_ARG")
-        OUTPUT_DIR_ABSOLUTE=$(realpath "$OUTPUT_DIR_RELATIVE")
-        OUTPUT_FILE=$(basename "$OUTPUT_ARG")
-        OUTPUT="${OUTPUT_DIR_ABSOLUTE}"/"${OUTPUT_FILE}"
-        shift 2
-        ;;
+      OUTPUT_ARG="$2"
+      OUTPUT_DIR_RELATIVE=$(dirname "$OUTPUT_ARG")
+      OUTPUT_DIR_ABSOLUTE=$(realpath "$OUTPUT_DIR_RELATIVE")
+      OUTPUT_FILE=$(basename "$OUTPUT_ARG")
+      OUTPUT="${OUTPUT_DIR_ABSOLUTE}"/"${OUTPUT_FILE}"
+      shift 2
+      ;;
     -c | --cpu_cores)
-        CPU_CORES="$2"
-        shift 2
-        ;;
+      CPU_CORES="$2"
+      shift 2
+      ;;
     -f | --force)
-        FORCE=1
-        shift
-        ;;
+      FORCE=1
+      shift
+      ;;
     -r | --reference)
-        INPUT_REF=$(realpath "$2")
-        shift 2
-        ;;
+      INPUT_REF=$(realpath "$2")
+      shift 2
+      ;;
     --)
-        shift
-        break
-        ;;
+      shift
+      break
+      ;;
     *)
-        usage
-	exit 2
-        ;;
+      usage
+	    exit 2
+      ;;
   esac
 done
 
-if [ -z ${INPUT} ]
+if [ -z "${INPUT}" ]
 then
-        echo "missing required option -i
-	"
+  echo -e "missing required option -i\n"
 	usage
 	exit 2
 fi
-if [ -z ${OUTPUT} ]
+if [ -z "${OUTPUT}" ]
 then
-        echo "missing required option -o
-	"
+  echo -e "missing required option -o\n"
 	usage
 	exit 2
-fi
-if [ -z ${CPU_CORES} ]
-then
-	CPU_CORES=4
-fi
-if [ -z ${FORCE} ]
-then
-	FORCE=0
 fi
 
 if [ ! -f "${INPUT}" ]
 then
-	echo "$INPUT does not exist.
-	"
+	echo -e "$INPUT does not exist.\n"
 	exit 2
 fi
 if [ -f "${OUTPUT}" ]
@@ -123,19 +112,17 @@ then
 	then
 		rm "${OUTPUT}"
 	else
-		echo "${OUTPUT} already exists, use -f to overwrite.
-        	"
-	        exit 2
+		echo -e "${OUTPUT} already exists, use -f to overwrite.\n"
+    exit 2
 	fi
 fi
 if [ ! -z "${INPUT_REF}" ]
 then
-                if [ ! -f "${INPUT_REF}" ]
-                then
-                        echo "${INPUT_REF} does not exist.
-                        "
-                        exit 2
-                fi
+  if [ ! -f "${INPUT_REF}" ]
+  then
+    echo -e "${INPUT_REF} does not exist.\n"
+    exit 2
+  fi
 fi
 
 PREPROCESS_INPUT="${INPUT}"
@@ -151,7 +138,7 @@ if [[ "${OUTPUT}" == *.vcf.gz ]]
 then
 	BCFTOOLS_ARGS+=" -O z"
 fi
-if [ ! -z ${INPUT_REF} ]; then
+if [ ! -z "${INPUT_REF}" ]; then
 	BCFTOOLS_ARGS+=" -f ${INPUT_REF} -c e"
 fi
 BCFTOOLS_ARGS+=" --threads ${CPU_CORES} ${PREPROCESS_INPUT}"

--- a/pipeline_report.sh
+++ b/pipeline_report.sh
@@ -24,7 +24,7 @@ INPUT=""
 INPUT_PED=""
 INPUT_PHENO=""
 OUTPUT=""
-FORCE=""
+FORCE=0
 
 usage()
 {
@@ -58,90 +58,81 @@ while :
 do
   case "$1" in
     -i | --input)
-        INPUT=$(realpath "$2")
-        shift 2
-        ;;
+      INPUT=$(realpath "$2")
+      shift 2
+      ;;
     -o | --output)
-        OUTPUT_ARG="$2"
-        OUTPUT_DIR_RELATIVE=$(dirname "$OUTPUT_ARG")
-        OUTPUT_DIR_ABSOLUTE=$(realpath "$OUTPUT_DIR_RELATIVE")
-        OUTPUT_FILE=$(basename "$OUTPUT_ARG")
-        OUTPUT="${OUTPUT_DIR_ABSOLUTE}"/"${OUTPUT_FILE}"
-        shift 2
-        ;;
+      OUTPUT_ARG="$2"
+      OUTPUT_DIR_RELATIVE=$(dirname "$OUTPUT_ARG")
+      OUTPUT_DIR_ABSOLUTE=$(realpath "$OUTPUT_DIR_RELATIVE")
+      OUTPUT_FILE=$(basename "$OUTPUT_ARG")
+      OUTPUT="${OUTPUT_DIR_ABSOLUTE}"/"${OUTPUT_FILE}"
+      shift 2
+      ;;
     -p | --pedigree)
-        INPUT_PED=$(realpath "$2")
-        shift 2
-        ;;
+      INPUT_PED=$(realpath "$2")
+      shift 2
+      ;;
     -t | --phenotypes)
-        INPUT_PHENO="$2"
-        echo "PHENO ${INPUT_PHENO}"
-        shift 2
-        ;;
+      INPUT_PHENO="$2"
+      echo "PHENO ${INPUT_PHENO}"
+      shift 2
+      ;;
     -f | --force)
-        FORCE=1
-        shift
-        ;;
+      FORCE=1
+      shift
+      ;;
     --)
-        shift
-        break
-        ;;
+      shift
+      break
+      ;;
     *)
-        usage
-	exit 2
-        ;;
+      usage
+	    exit 2
+      ;;
   esac
 done
 
 #FIXME map params
 
-if [ -z ${INPUT} ]
+if [ -z "${INPUT}" ]
 then
-        echo "missing required option -i
-	"
+  echo -e "missing required option -i\n"
 	usage
 	exit 2
 fi
-if [ -z ${OUTPUT} ]
+if [ -z "${OUTPUT}" ]
 then
-        echo "missing required option -o
-	"
+  echo -e "missing required option -o\n"
 	usage
 	exit 2
-fi
-if [ -z ${FORCE} ]
-then
-	FORCE=0
 fi
 
 if [ ! -f "${INPUT}" ]
 then
-	echo "$INPUT does not exist.
-	"
+	echo -e "$INPUT does not exist.\n"
 	exit 2
 fi
 if [ -f "${OUTPUT}" ]
 then
-        if [ "${FORCE}" == "1" ]
-        then
-                rm "${OUTPUT}"
-        else
-                echo "${OUTPUT} already exists, use -f to overwrite.
-                "
-                exit 2
-        fi
+  if [ "${FORCE}" == "1" ]
+  then
+    rm "${OUTPUT}"
+  else
+    echo -e "${OUTPUT} already exists, use -f to overwrite.\n"
+    exit 2
+  fi
 fi
-if [ ! -z ${INPUT_PED} ]
+if [ ! -z "${INPUT_PED}" ]
 then
-		if [ ! -f "${INPUT_PED}" ]
-		then
-			echo "${INPUT_PED} does not exist.
-			"
-			exit 2
-		fi
+  if [ ! -f "${INPUT_PED}" ]
+  then
+    echo -e "${INPUT_PED} does not exist.\n"
+    exit 2
+  fi
 fi
 
-if [ -z ${TMPDIR+x} ]; then
+if [ -z "${TMPDIR+x}" ]; then
 	TMPDIR=/tmp
 fi
 


### PR DESCRIPTION
- Added quotes to variables inside if statements ([argument](https://tldp.org/LDP/abs/html/quotingvar.html): "When referencing a variable, it is generally advisable to enclose its name in double quotes.")
  - Places that called a `sh`, `java` and alike, variables were not enclosed as this might break stuff.
- Replaced `echo` that included a literal new line to `echo -e` with a `\n` ([source](https://unix.stackexchange.com/a/189819), argument: cleaner code)
- Replaced "setting a default if no user-input was given after user-input digestion" to "set default at the top of the script where variable is declared" (argument: removes possible initial confusion when viewing scripts what the defaults are, if there are any)
- Removed a `\` at the end of the line of a Python execution where no additional arguments were given on the line afterwards (argument: unnecessary `\`)
- Fixed indentations (argument: strongly improved code readability, see also screenshot as pre-fix example)
- `$KEEP` & `$FORCE` use `0`/`1` **ONLY** instead of starting with empty string (argument: there were locations that checked using `if [ ! -z "${FORCE}" ]` after it was set to either `0` or `1`, so this approach should be more consistent as `-z` is a [String length check](https://linux.die.net/man/1/sh))
- Combined if/then inside if/then (without other options) into a single `if [x] && [y]` (argument: reduction of unnecessary code)

Example of indentation:
![Schermafbeelding 2020-09-14 om 19 08 28](https://user-images.githubusercontent.com/7658246/93116571-b68a7300-f6bd-11ea-98e1-9de0c1f0010f.png)

