### PR TITLE
Fix #65 Use CADD/v1.4-foss-2018b-minimal when available (backport)

### DIFF
--- a/utils/header.sh
+++ b/utils/header.sh
@@ -2,10 +2,15 @@
 set -euo pipefail
 
 MOD_BCF_TOOLS="BCFtools/1.10.2-GCCcore-7.3.0"
-MOD_CADD="CADD/v1.4-foss-2018b"
+MOD_CADD="CADD/v1.4-foss-2018b-minimal"
 MOD_CAPICE="CAPICE/v1.3.0-foss-2018b"
 MOD_HTS_LIB="HTSlib/1.10.2-GCCcore-7.3.0"
 MOD_VCF_ANNO="vcfanno/v0.3.2"
 MOD_VCF_DECISION_TREE="vcf-decision-tree/v0.0.1-Java-11-LTS"
 MOD_VCF_REPORT="vcf-report/v1.0.2-Java-11-LTS"
 MOD_VEP="VEP/100.4-foss-2018b-Perl-5.28.0"
+
+# Use non-minimal CADD module if the minimal module is not available
+if ! module is-avail "${MOD_CADD}"; then
+  MOD_CADD="${MOD_CADD%-minimal}"
+fi


### PR DESCRIPTION
## SOP
### Before merge:
- [will test when v1.1.x is available] Functionality works & meets specs
- [will test when v1.1.x is available] No issues running `sh test/pipeline_test.sh`
- [x] Code reviewed
- [N.A] Documentation was updated

### After merge:
- [ ] Added feature/fix to draft release notes

## Notes by PR author
None.
