### PR TITLE
Update vcf-inheritance-matcher/v0.0.3-Java-11-LTS to v0.1.0

### DIFF
--- a/utils/header.sh
+++ b/utils/header.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-VIP_VERSION="1.7.0"
+VIP_VERSION="1.7.1"
 
 MOD_BCF_TOOLS="BCFtools/1.11-GCCcore-7.3.0"
 MOD_CADD="CADD/v1.4-foss-2018b-minimal"
@@ -9,7 +9,7 @@ MOD_CAPICE="CAPICE/v1.3.0-foss-2018b"
 MOD_HTS_LIB="HTSlib/1.11-GCCcore-7.3.0"
 MOD_VCF_ANNO="vcfanno/v0.3.2"
 MOD_VCF_DECISION_TREE="vcf-decision-tree/v0.0.2-Java-11-LTS"
-MOD_VCF_INHERITANCE_MATCHER="vcf-inheritance-matcher/v0.0.3-Java-11-LTS"
+MOD_VCF_INHERITANCE_MATCHER="vcf-inheritance-matcher/v0.1.0-Java-11-LTS"
 MOD_VCF_REPORT="vcf-report/v1.7.0-Java-11-LTS"
 MOD_VEP="VEP/100.4-foss-2018b-Perl-5.28.0"
 MOD_VIBE="VIBE/5.0.1-Java-11-LTS"


### PR DESCRIPTION
## SOP
### Before merge:
- [ ] Functionality works & meets specs
- [x] No issues running `bash test/pipeline_test.sh`
- [x] Code reviewed
- [ ] Documentation was updated

### After merge:
- [ ] Added feature/fix to draft release notes

## Notes by PR author
None.
