### PR TITLE
Added Vagrantfile to easily allow building `.sif` files on MacOS.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 
 # Singularity image folder.
 singularity/sif
+
+# Vagrant folder.
+.vagrant/

--- a/README.md
+++ b/README.md
@@ -3,9 +3,19 @@
 ## Requirements
 - Any modern Linux distribution
 - Singularity (see [admin guide](https://sylabs.io/guides/latest/admin-guide/))
+- \[Windows\] [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/) (f.e. running Ubuntu)
+- \[MacOS\] [Vagrant](https://www.vagrantup.com/)
+- \[MacOS\] [VirtualBox](https://www.virtualbox.org/) (used by Vagrant)
 
 ## Installation
-Run `cd singularity; sudo bash build.sh` to build singularity images.
+### Linux/Windows (running WSL)
+Run `cd singularity && sudo bash build.sh` to build singularity images.
+
+### MacOS
+Run `vagrant up && vagrant ssh` to start and login to the vagrant container.
+From here, run `cd /vagrant/singularity/ && sudo bash build.sh` to build the singularity images.
+
+When done, you can exit the container through `exit` and then close it using `vagrant halt`.
 
 ## Usage
 ```
@@ -51,6 +61,10 @@ examples - phenotypes:
   pipeline.sh -i in.vcf.gz --phenotypes sample0/HP:0000123
   pipeline.sh -i in.vcf.gz --phenotypes sample0/HP:0000123,sample1/HP:0000234
 ```
+
+### MacOS
+Note that Vagrant only syncs the current folder. If using data that is stored elsewhere,
+be sure to adjust `config.vm.synced_folder` in the `Vagrantfile`.
 
 ## Usage: modules
 Pipeline modules can be used separately, run one of the following scripts for usage information:

--- a/README.md
+++ b/README.md
@@ -8,12 +8,19 @@
 - \[MacOS\] [VirtualBox](https://www.virtualbox.org/) (used by Vagrant)
 
 ## Installation
+**IMPORTANT:** The `pipeline.sh` (and related) scripts assume several directories being present such as `/apps`. These is currently not configured in the `Vagrantfile` and would require additional configuration in WSL as well.
+
 ### Linux/Windows (running WSL)
 Run `cd singularity && sudo bash build.sh` to build singularity images.
 
 ### MacOS
 Run `vagrant up && vagrant ssh` to start and login to the vagrant container.
 From here, run `cd /vagrant/singularity/ && sudo bash build.sh` to build the singularity images.
+
+When done, you can exit the Vagrant VM through `exit` and then shut it down with `vagrant halt`.
+
+Note that Vagrant only syncs the current folder. When using data stored elsewhere,
+be sure to adjust `config.vm.synced_folder` in the `Vagrantfile`.
 
 ## Usage
 ```
@@ -59,12 +66,6 @@ examples - phenotypes:
   pipeline.sh -i in.vcf.gz --phenotypes sample0/HP:0000123
   pipeline.sh -i in.vcf.gz --phenotypes sample0/HP:0000123,sample1/HP:0000234
 ```
-
-### MacOS
-When done, you can exit the Vagrant VM through `exit` and then shut it down with `vagrant halt`.
-
-Note that Vagrant only syncs the current folder. When using data stored elsewhere,
-be sure to adjust `config.vm.synced_folder` in the `Vagrantfile`.
 
 ## Usage: modules
 Pipeline modules can be used separately, run one of the following scripts for usage information:

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ Run `cd singularity && sudo bash build.sh` to build singularity images.
 Run `vagrant up && vagrant ssh` to start and login to the vagrant container.
 From here, run `cd /vagrant/singularity/ && sudo bash build.sh` to build the singularity images.
 
-When done, you can exit the container through `exit` and then close it using `vagrant halt`.
-
 ## Usage
 ```
 usage: pipeline.sh -i <arg>
@@ -63,7 +61,9 @@ examples - phenotypes:
 ```
 
 ### MacOS
-Note that Vagrant only syncs the current folder. If using data that is stored elsewhere,
+When done, you can exit the Vagrant VM through `exit` and then shut it down with `vagrant halt`.
+
+Note that Vagrant only syncs the current folder. When using data stored elsewhere,
 be sure to adjust `config.vm.synced_folder` in the `Vagrantfile`.
 
 ## Usage: modules

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,71 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "sylabs/singularity-ce-3.8-ubuntu-bionic64"
+  config.vm.box_version = "20210527.0.0"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Ansible, Chef, Docker, Puppet and Salt are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.provision "shell", inline: <<-SHELL
+    apt-get update
+    apt-get install -y curl
+  SHELL
+end


### PR DESCRIPTION
## Changes
- Added `Vagrantfile`.
- Updated README.
- Updated `.gitignore`.

## SOP
### Before merge:
- [ ] Functionality works & meets specs
- [ ] No issues running `bash test/pipeline_test.sh`
- [ ] Code reviewed
- [ ] Documentation was updated

### After merge:
- [ ] Added feature/fix to draft release notes

## Notes by PR author
`Vagrantfile` supports building (and running individual images if required data is present), `pipeline.sh` and similar scripts do not run due to lacking `/apps` folder. This is mentioned in the README.
