### PR TITLE
Fix multiple CAPICE VEP plugin issues

### DIFF
--- a/resources/vep/plugins/Capice.pm
+++ b/resources/vep/plugins/Capice.pm
@@ -49,10 +49,10 @@ sub create_key {
     my $pos = $_[1];
     my $ref = $_[2];
     my $alt = $_[3];
-    my $gene = $_[4];
-    my $source = $_[5];
-    my $feature_type = $_[6];
-    my $feature = $_[7];
+    my $gene = $_[4]?$_[4]:"";
+    my $source = $_[5]?$_[5]:"";
+    my $feature_type = $_[6]?$_[6]:"";
+    my $feature = $_[7]?$_[7]:"";
     return "${chr}_${pos}_${ref}_${alt}_${gene}_${source}_${feature_type}_${feature}";
 }
 

--- a/resources/vep/plugins/Capice.pm
+++ b/resources/vep/plugins/Capice.pm
@@ -56,6 +56,24 @@ sub create_key {
     return "${chr}_${pos}_${ref}_${alt}_${gene}_${source}_${feature_type}_${feature}";
 }
 
+sub getFeatureType {
+    my $tva = $_[0];
+    my $feature_type = "";
+    if($tva->isa('Bio::EnsEMBL::Variation::TranscriptVariationAllele')) {
+        $feature_type = "Transcript";
+    }
+    elsif($tva->isa('Bio::EnsEMBL::Variation::RegulatoryFeatureVariationAllele')) {
+        $feature_type = "RegulatoryFeature";
+    }
+    elsif($tva->isa('Bio::EnsEMBL::Variation::MotifFeatureVariationAllele')) {
+        $feature_type = "MotifFeature";
+    }
+    elsif($tva->isa('Bio::EnsEMBL::Variation::IntergenicVariationAllele')) {
+        $feature_type = "Intergenic";
+    }
+    return $feature_type;
+}
+
 sub parse_file_header {
     my @tokens = split /\t/, $_[0];
 
@@ -144,7 +162,9 @@ sub run {
         $transcript_id = $tva->feature->stable_id;
     }
 
-    my $key = create_key($chr,$pos,$ref,$alt,$gene,$source,$transcript_id);
+    my $feature_type = getFeatureType($tva);
+
+    my $key = create_key($chr,$pos,$ref,$alt,$gene,$source,$feature_type,$transcript_id);
 
     my $result = ();
     $result->{CAPICE_SC} = undef;


### PR DESCRIPTION
When there are empty fields at the end of a capice output line, no tabs are added.
This leads to the VEP plugin complaining about using undefined fields for a concatenation (e.g. 'feature'/'feature_type' fields)


## SOP
### Before merge:
- [ ] Functionality works & meets specs
- [ ] No issues running `bash test/pipeline_test.sh`
- [ ] Code reviewed
- [ ] Documentation was updated

### After merge:
- [ ] Added feature/fix to draft release notes

## Notes by PR author
None.
