### PR TITLE
fix: remove CAPICE from default decision tree

### DIFF
--- a/resources/decision_tree.json
+++ b/resources/decision_tree.json
@@ -85,10 +85,10 @@
         }
       },
       "outcomeMissing": {
-        "nextNode": "capice"
+        "nextNode": "clinVar"
       },
       "outcomeDefault": {
-        "nextNode": "capice"
+        "nextNode": "clinVar"
       }
     },
     "annotSV": {
@@ -148,24 +148,6 @@
       },
       "outcomeMissing": {
         "nextNode": "effect"
-      }
-    },
-    "capice": {
-      "type": "BOOL",
-      "description": "CAPICE score < 0.15",
-      "query": {
-        "field": "INFO/CSQ/CAPICE_SC",
-        "operator": "<",
-        "value": 0.15
-      },
-      "outcomeTrue": {
-        "nextNode": "exit_lb"
-      },
-      "outcomeFalse": {
-        "nextNode": "clinVar"
-      },
-      "outcomeMissing": {
-        "nextNode": "clinVar"
       }
     },
     "effect": {


### PR DESCRIPTION
```
executing tests ...
PASSED test_snv
PASSED test_snv_proband
PASSED test_snv_proband_trio
PASSED test_snv_proband_trio_b38
PASSED test_sv
PASSED test_lp
PASSED test_lb
all tests passed successfully
```