### PR TITLE
Introduce default filter tree exit state for unclassified variants (e.g. filter != PASS).

### DIFF
--- a/resources/decision_tree.json
+++ b/resources/decision_tree.json
@@ -15,7 +15,7 @@
         "nextNode": "vkgl"
       },
       "outcomeFalse": {
-        "nextNode": "exit_lb"
+        "nextNode": "exit_f"
       },
       "outcomeMissing": {
         "nextNode": "vkgl"
@@ -324,6 +324,11 @@
       "outcomeMissing": {
         "nextNode": "exit_vus"
       }
+    },
+    "exit_f": {
+      "description": "Variants to be filtered e.g. because of non 'PASS' FILTER state.",
+      "type": "LEAF",
+      "class": "F"
     },
     "exit_b": {
       "type": "LEAF",

--- a/resources/decision_tree.json
+++ b/resources/decision_tree.json
@@ -15,7 +15,7 @@
         "nextNode": "vkgl"
       },
       "outcomeFalse": {
-        "nextNode": "exit_f"
+        "nextNode": "exit_lq"
       },
       "outcomeMissing": {
         "nextNode": "vkgl"
@@ -325,10 +325,10 @@
         "nextNode": "exit_vus"
       }
     },
-    "exit_f": {
-      "description": "Variants to be filtered e.g. because of non 'PASS' FILTER state.",
+    "exit_lq": {
+      "description": "Low quality variants.",
       "type": "LEAF",
-      "class": "F"
+      "class": "LQ"
     },
     "exit_b": {
       "type": "LEAF",


### PR DESCRIPTION

## SOP
### Before merge:
- [ ] Functionality works & meets specs
- [ ] No issues running `bash test/pipeline_test.sh`
- [ ] Code reviewed
- [ ] Documentation was updated

### After merge:
- [ ] Added feature/fix to draft release notes

## Notes by PR author
None.
