### PR TITLE
'classify_samples' missing in the nextflow config, therefor running with only 100MB memory

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -90,7 +90,7 @@ profiles {
         time = '1h'
       }
 
-      withName:'classify|inheritance|report' {
+      withName:'classify|classify_samples|inheritance|report' {
         memory = '2GB'
       }
     }


### PR DESCRIPTION
…

## SOP
### Before merge:
- [ ] Functionality works & meets specs
- [ ] No issues running `bash test/pipeline_test.sh`
- [ ] Code reviewed
- [ ] Documentation was updated

### After merge:
- [ ] Added feature/fix to draft release notes

## Notes by PR author
None.
