### PR TITLE
feat: CAPICE 4.0.0 V2 support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,7 @@ download_resources_molgenis() {
   files+=("inheritance_20220712.tsv")
 
   if [ "${assembly}" == "ALL" ] || [ "${assembly}" == "GRCh37" ]; then
-    files+=("GRCh37/capice_model_v4.0.0-v1.pickle.dat")
+    files+=("GRCh37/capice_model_v4.0.0-v2.pickle.dat")
     files+=("GRCh37/clinvar_20220620.vcf.gz")
     files+=("GRCh37/clinvar_20220620.vcf.gz.tbi")
     files+=("GRCh37/gnomad.total.r2.1.1.sites.stripped.vcf.gz")
@@ -45,7 +45,7 @@ download_resources_molgenis() {
   fi
 
   if [ "${assembly}" == "ALL" ] || [ "${assembly}" == "GRCh38" ]; then
-    files+=("GRCh38/capice_model_v4.0.0-v1.pickle.dat")
+    files+=("GRCh38/capice_model_v4.0.0-v2.pickle.dat")
     files+=("GRCh38/clinvar_20220620.vcf.gz")
     files+=("GRCh38/clinvar_20220620.vcf.gz.tbi")
     files+=("GRCh38/gnomad.genomes.v3.1.2.sites.stripped.vcf.gz")

--- a/nextflow.config
+++ b/nextflow.config
@@ -40,7 +40,7 @@ params {
   GRCh37_annotate_vep_plugin_spliceai_snv = "${projectDir}/resources/GRCh37/spliceai_scores.masked.snv.hg19.vcf.gz"
   GRCh37_annotate_vep_plugin_utrannotator = "${projectDir}/resources/uORF_5UTR_GRCh37_PUBLIC.txt"
   GRCh37_annotate_vep_plugin_vkgl = "${projectDir}/resources/GRCh37/vkgl_consensus_20211201.tsv"
-  GRCh37_annotate_capice_model = "${projectDir}/resources/GRCh37/capice_model_v4.0.0-v1.pickle.dat"
+  GRCh37_annotate_capice_model = "${projectDir}/resources/GRCh37/capice_model_v4.0.0-v2.pickle.dat"
   GRCh37_report_genes = "${projectDir}/resources/GRCh37/GCF_000001405.25_GRCh37.p13_genomic_g1k.gff.gz"
 
   GRCh38_reference = "${projectDir}/resources/GRCh38/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.gz"
@@ -52,7 +52,7 @@ params {
   GRCh38_annotate_vep_plugin_spliceai_snv = "${projectDir}/resources/GRCh38/spliceai_scores.masked.snv.hg38.vcf.gz"
   GRCh38_annotate_vep_plugin_utrannotator = "${projectDir}/resources/uORF_5UTR_GRCh38_PUBLIC.txt"
   GRCh38_annotate_vep_plugin_vkgl = "${projectDir}/resources/GRCh38/vkgl_consensus_20211201.tsv"
-  GRCh38_annotate_capice_model = "${projectDir}/resources/GRCh38/capice_model_v4.0.0-v1.pickle.dat"
+  GRCh38_annotate_capice_model = "${projectDir}/resources/GRCh38/capice_model_v4.0.0-v2.pickle.dat"
   GRCh38_report_genes = "${projectDir}/resources/GRCh38/GCF_000001405.39_GRCh38.p13_genomic_mapped.gff.gz"
 
   singularity_image_dir = "${projectDir}/images"


### PR DESCRIPTION
- Added support for the version 2 models of CAPICE 4.0.0 (no heterozygous variants in AR genes)

## SOP
### Before merge:
- [ ] Functionality works & meets specs
- [x] No issues running `bash test/pipeline_test.sh`
- [x] Code reviewed
- [ ] Documentation was updated

### After merge:
- [ ] Added feature/fix to draft release notes

## Notes by PR author
None.
