### PR TITLE
docs: add links from config to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ for a schematic represeantation of the workflow [click here](./docs/vip_workflow
 |---------|----------|----------|---------------------------------------------------------------|
 | ``vcf`` | ``file`` | yes      | file extensions: [vcf, vcf.gz, vcf.bgz, bcf, bcf.gz, bcf.bgz] |
 | ``cram``| ``file`` |          | file extensions: [bam, cram]                                  |
-[example](#vcf-multi-project)
+
+See [example](#vcf-multi-project)
 
 #### Input CRAM
 | column                  | type          | required |                                              |
@@ -96,8 +97,9 @@ for a schematic represeantation of the workflow [click here](./docs/vip_workflow
 | ``fastq``               | ``file list`` |          | file extensions: [fastq, fastq.gz, fq, fq.gz] |
 | ``fastq_r1``            | ``file list`` |          | file extensions: [fastq, fastq.gz, fq, fq.gz] |
 | ``fastq_r2``            | ``file list`` |          | file extensions: [fastq, fastq.gz, fq, fq.gz] |
-| ``sequencing_platform`` | ``enum``      |          | default:illumina values: [illumina,nanopore]  |                   
-[example](#fastq-giab-hg001-illumina-hiseq-exome)
+| ``sequencing_platform`` | ``enum``      |          | default:illumina values: [illumina,nanopore]  |   
+
+See [example](#fastq-giab-hg001-illumina-hiseq-exome)
 
 ### Profile
 By default, VIP detects whether [Slurm](https://slurm.schedmd.com/) is available on the system and use the <code>slurm</code> profile. Otherwise, the <code>local</code> profile is used which executes the workflow on this machine. You can override the profile or refer to a custom profile specified in your <code>--config</code>.

--- a/README.md
+++ b/README.md
@@ -77,19 +77,19 @@ for a schematic represeantation of the workflow [click here](./docs/vip_workflow
 | ``hpo_ids``       | ``string list`` |          | regex: /HP:\d{7}/                      |
 | ``assembly``      | ``enum``        |          | default:GRCh38 values: [GRCh37,GRCh38] |
 
-#### Input VCF
+#### Input VCF ([example](#vcf-multi-project))
 | column  | type     | required |                                                               |
 |---------|----------|----------|---------------------------------------------------------------|
 | ``vcf`` | ``file`` | yes      | file extensions: [vcf, vcf.gz, vcf.bgz, bcf, bcf.gz, bcf.bgz] |
 | ``cram``| ``file`` |          | file extensions: [bam, cram]                                  |
 
-#### Input CRAM
+#### Input CRAM (example)
 | column                  | type          | required |                                              |
 |-------------------------|---------------|----------|----------------------------------------------|
 | ``cram``                | ``file``      | yes      | file extensions: [bam, cram]                 |
 | ``sequencing_platform`` | ``enum``      |          | default:illumina values: [illumina,nanopore] |
 
-#### Input FASTQ
+#### Input FASTQ ([example](#fastq-giab-hg001-illumina-hiseq-exome))
 | column                  | type          | required |                                               |
 |-------------------------|---------------|----------|-----------------------------------------------|
 | ``fastq``               | ``file list`` |          | file extensions: [fastq, fastq.gz, fq, fq.gz] |

--- a/README.md
+++ b/README.md
@@ -77,25 +77,27 @@ for a schematic represeantation of the workflow [click here](./docs/vip_workflow
 | ``hpo_ids``       | ``string list`` |          | regex: /HP:\d{7}/                      |
 | ``assembly``      | ``enum``        |          | default:GRCh38 values: [GRCh37,GRCh38] |
 
-#### Input VCF ([example](#vcf-multi-project))
+#### Input VCF
 | column  | type     | required |                                                               |
 |---------|----------|----------|---------------------------------------------------------------|
 | ``vcf`` | ``file`` | yes      | file extensions: [vcf, vcf.gz, vcf.bgz, bcf, bcf.gz, bcf.bgz] |
 | ``cram``| ``file`` |          | file extensions: [bam, cram]                                  |
+[example](#vcf-multi-project)
 
-#### Input CRAM (example)
+#### Input CRAM
 | column                  | type          | required |                                              |
 |-------------------------|---------------|----------|----------------------------------------------|
 | ``cram``                | ``file``      | yes      | file extensions: [bam, cram]                 |
 | ``sequencing_platform`` | ``enum``      |          | default:illumina values: [illumina,nanopore] |
 
-#### Input FASTQ ([example](#fastq-giab-hg001-illumina-hiseq-exome))
+#### Input FASTQ
 | column                  | type          | required |                                               |
 |-------------------------|---------------|----------|-----------------------------------------------|
 | ``fastq``               | ``file list`` |          | file extensions: [fastq, fastq.gz, fq, fq.gz] |
 | ``fastq_r1``            | ``file list`` |          | file extensions: [fastq, fastq.gz, fq, fq.gz] |
 | ``fastq_r2``            | ``file list`` |          | file extensions: [fastq, fastq.gz, fq, fq.gz] |
-| ``sequencing_platform`` | ``enum``      |          | default:illumina values: [illumina,nanopore]  |                   |
+| ``sequencing_platform`` | ``enum``      |          | default:illumina values: [illumina,nanopore]  |                   
+[example](#fastq-giab-hg001-illumina-hiseq-exome)
 
 ### Profile
 By default, VIP detects whether [Slurm](https://slurm.schedmd.com/) is available on the system and use the <code>slurm</code> profile. Otherwise, the <code>local</code> profile is used which executes the workflow on this machine. You can override the profile or refer to a custom profile specified in your <code>--config</code>.


### PR DESCRIPTION
I would like to see links to simple examples high up in the manual so the most common use cases give me a samplesheet to start from. Are there useful sheets to point to in this folder? 

https://github.com/molgenis/vip/tree/main/test/resources

Meanwhile made links within the readme.

End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
