### PR TITLE
fix:remove unused vcf.report.bams param

### DIFF
--- a/config/nxf_vcf.config
+++ b/config/nxf_vcf.config
@@ -113,7 +113,6 @@ params {
     }
 
     report {
-      bams = ""
       max_records = ""
       max_samples = ""
       template = ""


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
