### PR TITLE
chore:bump vcf-report 5.1.5 to 5.1.6

### DIFF
--- a/config/nxf.config
+++ b/config/nxf.config
@@ -1,5 +1,5 @@
 env {
-  VIP_VERSION = "5.0.3"
+  VIP_VERSION = "5.0.4"
 
   TMPDIR = "\${TMPDIR:-\${NXF_TEMP:-\$(mktemp -d)}}"
   APPTAINER_BIND = "${APPTAINER_BIND}"

--- a/config/nxf_vcf.config
+++ b/config/nxf_vcf.config
@@ -9,7 +9,7 @@ env {
   CMD_FILTERVEP = "apptainer exec --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vep-107.0.sif filter_vep"
   CMD_BGZIP = "apptainer exec --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vep-107.0.sif bgzip"
   CMD_SAMTOOLS= "apptainer exec --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/samtools-1.16.sif samtools"
-  CMD_VCFREPORT="apptainer exec --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-report-5.1.5.sif"
+  CMD_VCFREPORT="apptainer exec --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-report-5.1.6.sif"
   CMD_VCFDECISIONTREE = "apptainer exec --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-decision-tree-3.5.1.sif"
   CMD_VCFINHERITANCEMATCHER = "apptainer exec --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-inheritance-matcher-2.1.4.sif"
 }

--- a/install.sh
+++ b/install.sh
@@ -190,7 +190,7 @@ download_images() {
   files+=("samtools-1.16.sif")
   files+=("vcf-decision-tree-3.5.1.sif")
   files+=("vcf-inheritance-matcher-2.1.4.sif")
-  files+=("vcf-report-5.1.5.sif")
+  files+=("vcf-report-5.1.6.sif")
   files+=("vep-107.0.sif")
 
   for file in "${files[@]}"; do

--- a/utils/apptainer/build.sh
+++ b/utils/apptainer/build.sh
@@ -87,7 +87,7 @@ main() {
   images+=("samtools-1.16")
   images+=("vcf-decision-tree-3.5.1")
   images+=("vcf-inheritance-matcher-2.1.4")
-  images+=("vcf-report-5.1.5")
+  images+=("vcf-report-5.1.6")
   
   for i in "${!images[@]}"; do
     echo "---Building ${images[$i]}---"

--- a/utils/apptainer/def/vcf-report-5.1.6.def
+++ b/utils/apptainer/def/vcf-report-5.1.6.def
@@ -8,7 +8,7 @@ From: sif/build/openjdk-17.sif
 %post
     version_major=5
     version_minor=1
-    version_patch=5
+    version_patch=6
 
     # install
     apk update
@@ -16,7 +16,7 @@ From: sif/build/openjdk-17.sif
 
     mkdir -p /opt/vcf-report/lib
     curl -Ls -o /opt/vcf-report/lib/vcf-report.jar "https://github.com/molgenis/vip-report/releases/download/v${version_major}.${version_minor}.${version_patch}/vcf-report.jar"
-    echo "c750eada2d80489d8f2a00bf05d55c91e86f5f748e80864baa7ba93eefdc62cc  /opt/vcf-report/lib/vcf-report.jar" | sha256sum -c
+    echo "989fe98da527bc0db1b8b03ecc5e07a2658b59dbc134c83c7794685cc658e0d5  /opt/vcf-report/lib/vcf-report.jar" | sha256sum -c
 
     # cleanup
     apk del .build-dependencies


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
