### PR TITLE
Fix #322 Cram workflow can fail in case of 'B' nucleotide in reference

### DIFF
--- a/config/nxf.config
+++ b/config/nxf.config
@@ -1,5 +1,5 @@
 env {
-  VIP_VERSION = "5.0.4"
+  VIP_VERSION = "5.0.5"
 
   TMPDIR = "\${TMPDIR:-\${NXF_TEMP:-\$(mktemp -d)}}"
   APPTAINER_BIND = "${APPTAINER_BIND}"

--- a/modules/cram/clair3.nf
+++ b/modules/cram/clair3.nf
@@ -10,7 +10,7 @@ process clair3_call {
     bedContent = meta.chunk.regions.collect { region -> "${region.chrom}\t${region.chromStart}\t${region.chromEnd}" }.join("\n")
     
     vcfOut="${meta.sample.individual_id}_${meta.chunk.index}.vcf.gz"
-    vcfOutIndex="${vcfOut}.tbi"
+    vcfOutIndex="${vcfOut}.csi"
     vcfOutStats="${vcfOut}.stats"
 
     platform=meta.sample.sequencing_platform == "nanopore" ? "ont" : "ilmn"

--- a/modules/cram/templates/clair3_call.sh
+++ b/modules/cram/templates/clair3_call.sh
@@ -20,18 +20,19 @@ call_small_variants () {
     # Prevent Clair3 writing in home directory via samtools (https://www.htslib.org/doc/samtools.html#ENVIRONMENT_VARIABLES)
     XDG_CACHE_HOME=$(realpath .) ${CMD_CLAIR3} "${args[@]}"
 
-    mv "merge_output.vcf.gz" "!{vcfOut}"
-    mv "merge_output.vcf.gz.tbi" "!{vcfOutIndex}"
+    # Workaround for https://github.com/HKU-BAL/Clair3/issues/153
+    zcat "merge_output.vcf.gz" | awk -v FS='\t' -v OFS='\t' '/^[^#]/{sub(/[RYSWKMBDHV]/, "N", $4) sub(/[RYSWKMBDHV]/, "N", $5)} 1' | ${CMD_BCFTOOLS} view --output-type z --output "!{vcfOut}" --no-version --threads "!{task.cpus}"
 }
 
-stats () {
+index () {
+  ${CMD_BCFTOOLS} index --csi --output "!{vcfOutIndex}" --threads "!{task.cpus}" "!{vcfOut}"
   ${CMD_BCFTOOLS} index --stats "!{vcfOut}" > "!{vcfOutStats}"
 }
 
 main() {
     create_bed
     call_small_variants
-    stats
+    index
 }
 
 main "$@"


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
