### PR TITLE
Workaround for clair3 cram issue

### DIFF
--- a/modules/cram/templates/clair3_call.sh
+++ b/modules/cram/templates/clair3_call.sh
@@ -5,6 +5,8 @@ create_bed () {
   echo -e "!{bedContent}" > "!{bed}"
 }
 
+# workaround for clair 3 issue where the ebi server is called to decode the cram
+# https://github.com/HKU-BAL/Clair3/issues/180
 convert_to_bam () {
   ${CMD_SAMTOOLS} view --reference "!{reference}" --bam --output "!{cram}.bam" --threads "!{task.cpus}" "!{cram}"
   ${CMD_SAMTOOLS} index "!{cram}.bam"

--- a/modules/cram/templates/clair3_call.sh
+++ b/modules/cram/templates/clair3_call.sh
@@ -5,9 +5,14 @@ create_bed () {
   echo -e "!{bedContent}" > "!{bed}"
 }
 
+convert_to_bam () {
+  ${CMD_SAMTOOLS} view -T "!{reference}" -b -o !{cram}.bam !{cram}
+  ${CMD_SAMTOOLS} index "!{cram}.bam"
+}
+
 call_small_variants () {
     local args=()
-    args+=("--bam_fn=!{cram}")
+    args+=("--bam_fn=!{cram}.bam")
     args+=("--ref_fn=$(realpath "!{reference}")")
     args+=("--bed_fn=$(realpath "!{bed}")")
     args+=("--threads=!{task.cpus}")
@@ -31,6 +36,7 @@ index () {
 
 main() {
     create_bed
+    convert_to_bam
     call_small_variants
     index
 }

--- a/modules/cram/templates/clair3_call.sh
+++ b/modules/cram/templates/clair3_call.sh
@@ -6,7 +6,7 @@ create_bed () {
 }
 
 convert_to_bam () {
-  ${CMD_SAMTOOLS} view -T "!{reference}" -b -o !{cram}.bam !{cram}
+  ${CMD_SAMTOOLS} view --reference "!{reference}" --bam --output "!{cram}.bam" --threads "!{task.cpus}" "!{cram}"
   ${CMD_SAMTOOLS} index "!{cram}.bam"
 }
 


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
