### PR TITLE
chore: Bump alpine to 3.17.2

### DIFF
--- a/utils/apptainer/def/build/alpine-3.17.2.def
+++ b/utils/apptainer/def/build/alpine-3.17.2.def
@@ -1,0 +1,17 @@
+Bootstrap: scratch
+
+%help
+    Apptainer container running Alpine Linux
+
+%setup
+    version_major=3
+    version_minor=17
+    version_patch=2
+
+    alpine_minirootfs="alpine-minirootfs-${version_major}.${version_minor}.${version_patch}-x86_64.tar.gz"
+    alpine_minirootfs_url="http://dl-cdn.alpinelinux.org/alpine/v${version_major}.${version_minor}/releases/x86_64/${alpine_minirootfs}"
+    alpine_minirootfs_path="${APPTAINER_TMPDIR}/${alpine_minirootfs}"
+
+    curl -s -o "${alpine_minirootfs_path}" "${alpine_minirootfs_url}"
+    echo "b10fc6a33e462b9ccf704436071771051728d30f5d8b48adcddb9523c4c45328  ${alpine_minirootfs_path}" | sha256sum -c
+    tar xzf "${alpine_minirootfs_path}" -C "${APPTAINER_ROOTFS}" --exclude=./dev --exclude=./etc/hosts


### PR DESCRIPTION
Added def file for Alpine 3.17.2 in the 3.15.0 style.
