### PR TITLE
chore: bump Picard to 3.0.0

### DIFF
--- a/utils/apptainer/def/utils/picard-3.0.0.def
+++ b/utils/apptainer/def/utils/picard-3.0.0.def
@@ -1,0 +1,25 @@
+Bootstrap: localimage
+From: sif/build/alpine-3.17.2.sif
+
+%help
+    A set of Java command line tools for manipulating high-throughput sequencing (HTS) data and formats..
+    Usage: java -jar /opt/picard/lib/picard.jar
+
+%post
+    version_major=3
+    version_minor=0
+    version_patch=0
+
+    # install
+    apk update
+    apk --no-cache add gcompat
+	apk --no-cache add openjdk18-jre-headless
+    apk add --virtual=.build-dependencies curl
+
+    mkdir -p /opt/picard/lib
+    curl -Ls -o /opt/picard/lib/picard.jar "https://github.com/broadinstitute/picard/releases/download/${version_major}.${version_minor}.${version_patch}/picard.jar"
+    echo "0d5e28ab301fad3b02030d01923888129ba82c5f722ac5ccb2d418ab76ac5499  /opt/picard/lib/picard.jar" | sha256sum -c
+
+    # cleanup
+    apk del .build-dependencies
+    rm -rf /var/cache/apk/*


### PR DESCRIPTION
Added def file for picard-3.0.0, in the style of 2.26.11. Depends on chore/bumpAlpine.

End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
