### PR TITLE
fix:remove call to undefined stats function in sniffles2_call.sh

### DIFF
--- a/modules/cram/templates/sniffles2_call.sh
+++ b/modules/cram/templates/sniffles2_call.sh
@@ -42,7 +42,6 @@ main() {
     create_cram_slice
     call_structural_variants
     create_cram_slice_cleanup
-    stats
 }
 
 main "$@"


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
