### PR TITLE
fix:reheader workaround

### DIFF
--- a/modules/vcf/templates/merge_gvcf.sh
+++ b/modules/vcf/templates/merge_gvcf.sh
@@ -39,7 +39,7 @@ reheader_cleanup () {
 main () {
   reheader
   merge
-  #reheader_cleanup
+  reheader_cleanup
   index
 }
 

--- a/modules/vcf/templates/merge_gvcf.sh
+++ b/modules/vcf/templates/merge_gvcf.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # workaround contains a workaround for https://github.com/samtools/bcftools/issues/1425
 reheader () {
   echo -e "##fileformat=VCFv4.2\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO" > empty.vcf
-  ${CMD_BCFTOOLS} reheader --fai "!{refSeqFaiPath}" --output-type z --threads "!{task.cpus}" empty.vcf | ${CMD_BGZIP} -c > empty_contigs.vcf.gz
+  ${CMD_BCFTOOLS} reheader --fai "!{refSeqFaiPath}" --threads "!{task.cpus}" empty.vcf | ${CMD_BGZIP} -c > empty_contigs.vcf.gz
   ${CMD_BCFTOOLS} index --csi --threads "!{task.cpus}" empty_contigs.vcf.gz
 
   for gVcf in !{gVcfs}; do

--- a/modules/vcf/templates/merge_gvcf.sh
+++ b/modules/vcf/templates/merge_gvcf.sh
@@ -5,11 +5,11 @@ set -euo pipefail
 # workaround contains a workaround for https://github.com/samtools/bcftools/issues/1425
 reheader () {
   echo -e "##fileformat=VCFv4.2\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO" > empty.vcf
-  ${CMD_BCFTOOLS} reheader --fai "!{refSeqFaiPath}" --output "empty_contigs.vcf" --threads "!{task.cpus}" empty.vcf
-
+  ${CMD_BCFTOOLS} reheader --fai "!{refSeqFaiPath}" --output-type z --threads "!{task.cpus}" empty.vcf | ${CMD_BGZIP} -c > empty_contigs.vcf.gz
+  ${CMD_BCFTOOLS} index --csi --threads "!{task.cpus}" empty_contigs.vcf.gz
 
   for gVcf in !{gVcfs}; do
-    ${CMD_BCFTOOLS} merge --output-type z --output "reheadered_${gVcf}" --no-version --threads "!{task.cpus}" empty_contigs.vcf "${gVcf}"
+    ${CMD_BCFTOOLS} merge --output-type z --output "reheadered_${gVcf}" --no-version --threads "!{task.cpus}" empty_contigs.vcf.gz "${gVcf}"
   done
 }
 

--- a/modules/vcf/templates/merge_gvcf.sh
+++ b/modules/vcf/templates/merge_gvcf.sh
@@ -9,7 +9,7 @@ reheader () {
 
 
   for gVcf in !{gVcfs}; do
-    ${CMD_BCFTOOLS} concat --output-type z --output "reheadered_${gVcf}" --no-version --threads "!{task.cpus}" empty_contigs.vcf "${gVcf}"
+    ${CMD_BCFTOOLS} merge --output-type z --output "reheadered_${gVcf}" --no-version --threads "!{task.cpus}" empty_contigs.vcf "${gVcf}"
   done
 }
 


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes

```
[umcg-dhendriksen@gearshift test]$ bash test.sh
executing tests ...
PASSED gvcf
PASSED test_empty_input
PASSED test_empty_output_filter
PASSED test_empty_output_filter_samples
PASSED test_multiproject
PASSED test_multiproject_classify
PASSED test_corner_cases
PASSED test_snv_proband
PASSED test_snv_proband_trio
PASSED test_snv_proband_trio_sample_filtering
PASSED test_snv_proband_trio_b38
PASSED test_lp
PASSED test_lp_b38
PASSED test_lb
PASSED test_lb_b38
all tests passed successfully
executing tests ...
PASSED bam
PASSED cram
PASSED cram_multiproject
PASSED cram_trio
all tests passed successfully
executing tests ...
PASSED fastq_pacbio_hifi
```