### PR TITLE
vcf multiproject classify test runs local

### DIFF
--- a/test/test_vcf.sh
+++ b/test/test_vcf.sh
@@ -110,7 +110,6 @@ test_multiproject_classify () {
   args+=("--config" "${OUTPUT_DIR}/custom.cfg")
   args+=("--output" "${OUTPUT_DIR}")
   args+=("--resume")
-  args+=("--profile" "local")
 
   if ! "${CMD_VIP}" "${args[@]}" > /dev/null 2>&1; then
     return 1


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
