### PR TITLE
bump vcf-inheritance 3.1.0 to 3.1.2

### DIFF
--- a/utils/apptainer/def/utils/vcf-inheritance-3.1.2.def
+++ b/utils/apptainer/def/utils/vcf-inheritance-3.1.2.def
@@ -8,7 +8,7 @@ From: sif/build/openjdk-17.sif
 %post
     version_major=3
     version_minor=1
-    version_patch=0
+    version_patch=2
 
     # install
     apk update
@@ -16,7 +16,7 @@ From: sif/build/openjdk-17.sif
 
     mkdir -p /opt/vcf-inheritance/lib
     curl -Ls -o /opt/vcf-inheritance/lib/genemap-mapper.jar "https://github.com/molgenis/vip-inheritance/releases/download/v${version_major}.${version_minor}.${version_patch}/genemap-mapper.jar"
-    echo "e572cffeb93f78ef08ddcfea4917cb636832e1aec4434cb89203acd6aa1358c5  /opt/vcf-inheritance/lib/genemap-mapper.jar" | sha256sum -c
+    echo "6e86ff6ddf815dfc527d280061035b389a10bd67cf88c349fcddd330f738f85b  /opt/vcf-inheritance/lib/genemap-mapper.jar" | sha256sum -c
 
     # cleanup
     apk del .build-dependencies

--- a/utils/create_inheritance.sh
+++ b/utils/create_inheritance.sh
@@ -49,7 +49,7 @@ main() {
   done
 
   echo -e "downloading ..."
-  wget --quiet --continue https://download.molgeniscloud.org/downloads/vip/images/utils/vcf-inheritance-3.1.0.sif
+  wget --quiet --continue https://download.molgeniscloud.org/downloads/vip/images/utils/vcf-inheritance-3.1.2.sif
   wget --quiet --continue https://download.molgeniscloud.org/downloads/vip/resources/utils/incomplete_penetrantie_genes_entrez_20210125.tsv
   wget --quiet --continue http://purl.obolibrary.org/obo/hp/hpoa/phenotype.hpoa
   wget --quiet --continue https://research.nhgri.nih.gov/CGD/download/txt/CGD.txt.gz
@@ -75,7 +75,7 @@ main() {
   args+=("-f")
 
   echo -e "creating ${outputPath} ..."
-  apptainer exec vcf-inheritance-3.1.0.sif java "${args[@]}"
+  apptainer exec vcf-inheritance-3.1.2.sif java "${args[@]}"
   echo -e "creating ${outputPath} done"
 }
 


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
