### PR TITLE
Fix #367 Workaround for VEP out-of-memory errors

### DIFF
--- a/modules/cram/templates/manta_call.sh
+++ b/modules/cram/templates/manta_call.sh
@@ -36,7 +36,7 @@ run_manta () {
 
 # workaround for https://github.com/Ensembl/ensembl-vep/issues/1414
 filter_manta () {
-  ${CMD_BCFTOOLS} view -i 'FILTER="PASS"|FILTER="."' --output-type z --output "!{vcfOut}" --no-version --threads "!{task.cpus}" "results/variants/diploidSV.vcf.gz"
+  ${CMD_BCFTOOLS} view --include 'FILTER="PASS"|FILTER="."' --output-type z --output "!{vcfOut}" --no-version --threads "!{task.cpus}" "results/variants/diploidSV.vcf.gz"
 }
 
 stats () {

--- a/modules/cram/templates/manta_call.sh
+++ b/modules/cram/templates/manta_call.sh
@@ -32,8 +32,11 @@ run_manta () {
     args+=("-j" "!{task.cpus}")
 
     ${CMD_MANTA} "${args[@]}"
+}
 
-    mv "$(realpath .)/results/variants/diploidSV.vcf.gz" "!{vcfOut}"
+# workaround for https://github.com/Ensembl/ensembl-vep/issues/1414
+filter_manta () {
+  ${CMD_BCFTOOLS} view -i 'FILTER="PASS"|FILTER="."' --output-type z --output "!{vcfOut}" --no-version --threads "!{task.cpus}" "diploidSV.vcf.gz"
 }
 
 stats () {
@@ -45,6 +48,8 @@ main() {
     create_bed
     config_manta
     run_manta
+    # workaround for https://github.com/Ensembl/ensembl-vep/issues/1414
+    filter_manta
     stats
 }
 

--- a/modules/cram/templates/manta_call.sh
+++ b/modules/cram/templates/manta_call.sh
@@ -36,7 +36,7 @@ run_manta () {
 
 # workaround for https://github.com/Ensembl/ensembl-vep/issues/1414
 filter_manta () {
-  ${CMD_BCFTOOLS} view -i 'FILTER="PASS"|FILTER="."' --output-type z --output "!{vcfOut}" --no-version --threads "!{task.cpus}" "diploidSV.vcf.gz"
+  ${CMD_BCFTOOLS} view -i 'FILTER="PASS"|FILTER="."' --output-type z --output "!{vcfOut}" --no-version --threads "!{task.cpus}" "results/variants/diploidSV.vcf.gz"
 }
 
 stats () {


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
