### PR TITLE
fix:bump vcf-decision-tree 3.5.3 to 3.5.4

### DIFF
--- a/config/nxf_vcf.config
+++ b/config/nxf_vcf.config
@@ -10,7 +10,7 @@ env {
   CMD_BGZIP = "apptainer exec --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vep-109.3.sif bgzip"
   CMD_SAMTOOLS= "apptainer exec --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/samtools-1.17.sif samtools"
   CMD_VCFREPORT="apptainer exec --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-report-5.3.0.sif"
-  CMD_VCFDECISIONTREE = "apptainer exec --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-decision-tree-3.5.3.sif"
+  CMD_VCFDECISIONTREE = "apptainer exec --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-decision-tree-3.5.4.sif"
   CMD_VCFINHERITANCEMATCHER = "apptainer exec --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-inheritance-matcher-2.1.6.sif"
 
   // workaround for SAMtools https://github.com/samtools/samtools/issues/1366#issuecomment-769170935

--- a/install.sh
+++ b/install.sh
@@ -190,7 +190,7 @@ download_images() {
   files+=("glnexus_v1.4.5-patched.sif")
   files+=("minimap2-2.24.sif")
   files+=("samtools-1.17.sif")
-  files+=("vcf-decision-tree-3.5.3.sif")
+  files+=("vcf-decision-tree-3.5.4.sif")
   files+=("vcf-inheritance-matcher-2.1.6.sif")
   files+=("vcf-report-5.3.0.sif")
   files+=("vep-109.3.sif")

--- a/utils/apptainer/build.sh
+++ b/utils/apptainer/build.sh
@@ -85,7 +85,7 @@ main() {
   #images+=("glnexus_v1.4.5-patched")
   images+=("minimap2-2.24")
   images+=("samtools-1.17")
-  images+=("vcf-decision-tree-3.5.3")
+  images+=("vcf-decision-tree-3.5.4")
   images+=("vcf-inheritance-matcher-2.1.6")
   images+=("vcf-report-5.3.0")
   images+=("manta-1.6.0")

--- a/utils/apptainer/def/vcf-decision-tree-3.5.4.def
+++ b/utils/apptainer/def/vcf-decision-tree-3.5.4.def
@@ -8,7 +8,7 @@ From: sif/build/openjdk-17.sif
 %post
     version_major=3
     version_minor=5
-    version_patch=3
+    version_patch=4
 
     # install
     apk update
@@ -16,7 +16,7 @@ From: sif/build/openjdk-17.sif
 
     mkdir -p /opt/vcf-decision-tree/lib
     curl -Ls -o /opt/vcf-decision-tree/lib/vcf-decision-tree.jar "https://github.com/molgenis/vip-decision-tree/releases/download/v${version_major}.${version_minor}.${version_patch}/vcf-decision-tree.jar"
-    echo "b547e01832e11aba9f3ca04a442febb481c27e7a5ede46d22e0aec3101b04390  /opt/vcf-decision-tree/lib/vcf-decision-tree.jar" | sha256sum -c
+    echo "4af1f558ed7990252c8a522dea0fa5baf387ebd22dfb6747dfa93de141db429f  /opt/vcf-decision-tree/lib/vcf-decision-tree.jar" | sha256sum -c
 
     # cleanup
     apk del .build-dependencies


### PR DESCRIPTION
```
executing tests ...
PASSED gvcf
PASSED test_empty_input
PASSED test_empty_output_filter
PASSED test_empty_output_filter_samples
PASSED test_multiproject
PASSED test_multiproject_classify
PASSED test_corner_cases
PASSED test_snv_proband
PASSED test_snv_proband_trio
PASSED test_snv_proband_trio_sample_filtering
PASSED test_snv_proband_trio_b38
PASSED test_lp
PASSED test_lp_b38
PASSED test_lb
PASSED test_lb_b38
all tests passed successfully
```