### PR TITLE
Validate vcf after clair3 run

### DIFF
--- a/config/nxf_cram.config
+++ b/config/nxf_cram.config
@@ -36,6 +36,7 @@ process {
     cpus = 4
     memory = '8GB'
     time = '5h'
+    //Retry once because of https://github.com/HKU-BAL/Clair3/issues/200
     errorStrategy = 'retry'
     maxRetries = 1
   }

--- a/config/nxf_cram.config
+++ b/config/nxf_cram.config
@@ -36,6 +36,8 @@ process {
     cpus = 4
     memory = '8GB'
     time = '5h'
+    errorStrategy = 'retry'
+    maxRetries = 1
   }
   withName: 'manta_call' {
     cpus = 4

--- a/modules/cram/templates/clair3_call.sh
+++ b/modules/cram/templates/clair3_call.sh
@@ -41,11 +41,17 @@ stats () {
   ${CMD_BCFTOOLS} index --stats "!{vcfOut}" > "!{vcfOutStats}"
 }
 
+#To exit with error when https://github.com/HKU-BAL/Clair3/issues/200 occurs, otherwise it will fail in the next steps of the pipeline without possibility of the "retry stategy".
+validate () {
+  ${CMD_BCFTOOLS} view "!{vcfOut}" > /dev/null
+}
+
 main() {
     create_bed
     convert_to_bam
     call_small_variants
     convert_to_bam_cleanup
+    validate
     stats
 }
 


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes

Cram tests in progress...

----

To enable 'retry' after https://github.com/HKU-BAL/Clair3/issues/200

Manual test of this construction with a vcf containing as described in the clair3 issue:
`bcftools view /invalid.vcf.gz  > /dev/null`
```
[E::vcf_parse_format] Invalid character 'c' in 'PL' FORMAT field at chr1:1234
Error: VCF parse error
```

Retry config tested with an `exit 1` in the "validate()"