### PR TITLE
Fix #385 VEP out-of-memory workaround: replace bigWig with bed

### DIFF
--- a/config/nxf_vcf.config
+++ b/config/nxf_vcf.config
@@ -68,7 +68,8 @@ params {
         capice_model = "${projectDir}/resources/GRCh37/capice_model_v5.0.0-v1.ubj"
         vep_custom_gnomad = "${projectDir}/resources/GRCh37/gnomad.total.r2.1.1.sites.stripped.patch1.vcf.gz"
         vep_custom_clinvar = "${projectDir}/resources/GRCh37/clinvar_20230115.vcf.gz"
-        vep_custom_phylop = "${projectDir}/resources/GRCh37/hg19.100way.phyloP100way.bw"
+        // workaround for https://github.com/Ensembl/ensembl-vep/issues/1414
+        vep_custom_phylop = "${projectDir}/resources/GRCh37/hg19.100way.phyloP100way.bed.gz"
         vep_plugin_spliceai_indel = "${projectDir}/resources/GRCh37/spliceai_scores.masked.indel.hg19.vcf.gz"
         vep_plugin_spliceai_snv = "${projectDir}/resources/GRCh37/spliceai_scores.masked.snv.hg19.vcf.gz"
         vep_plugin_utrannotator = "${projectDir}/resources/GRCh37/uORF_5UTR_PUBLIC.txt"
@@ -79,7 +80,8 @@ params {
         capice_model = "${projectDir}/resources/GRCh38/capice_model_v5.0.0-v1.ubj"
         vep_custom_gnomad = "${projectDir}/resources/GRCh38/gnomad.genomes.v3.1.2.sites.stripped.vcf.gz"
         vep_custom_clinvar = "${projectDir}/resources/GRCh38/clinvar_20230115.vcf.gz"
-        vep_custom_phylop = "${projectDir}/resources/GRCh38/hg38.phyloP100way.bw"
+        // workaround for https://github.com/Ensembl/ensembl-vep/issues/1414
+        vep_custom_phylop = "${projectDir}/resources/GRCh38/hg38.phyloP100way.bed.gz"
         vep_plugin_spliceai_indel = "${projectDir}/resources/GRCh38/spliceai_scores.masked.indel.hg38.vcf.gz"
         vep_plugin_spliceai_snv = "${projectDir}/resources/GRCh38/spliceai_scores.masked.snv.hg38.vcf.gz"
         vep_plugin_utrannotator = "${projectDir}/resources/GRCh38/uORF_5UTR_PUBLIC.txt"

--- a/install.sh
+++ b/install.sh
@@ -58,7 +58,9 @@ download_resources_molgenis() {
     files+=("GRCh37/GCF_000001405.25_GRCh37.p13_genomic_g1k.gff.gz")
     files+=("GRCh37/gnomad.total.r2.1.1.sites.stripped.patch1.vcf.gz")
     files+=("GRCh37/gnomad.total.r2.1.1.sites.stripped.patch1.vcf.gz.csi")
-    files+=("GRCh37/hg19.100way.phyloP100way.bw")
+    # workaround for https://github.com/Ensembl/ensembl-vep/issues/1414
+    files+=("GRCh37/hg19.100way.phyloP100way.bed.gz")
+    files+=("GRCh37/hg19.100way.phyloP100way.bed.gz.tbi")
     files+=("GRCh37/human_g1k_v37.dict")
     #FIXME: remove line below after clair 3 is fixed
     files+=("GRCh37/human_g1k_v37.fasta.fai")
@@ -89,7 +91,9 @@ download_resources_molgenis() {
     files+=("GRCh38/GCF_000001405.39_GRCh38.p13_genomic_mapped.gff.gz")
     files+=("GRCh38/gnomad.genomes.v3.1.2.sites.stripped.vcf.gz")
     files+=("GRCh38/gnomad.genomes.v3.1.2.sites.stripped.vcf.gz.csi")
-    files+=("GRCh38/hg38.phyloP100way.bw")
+    # workaround for https://github.com/Ensembl/ensembl-vep/issues/1414
+    files+=("GRCh38/hg38.phyloP100way.bed.gz")
+    files+=("GRCh38/hg38.phyloP100way.bed.gz.tbi")
     files+=("GRCh38/spliceai_scores.masked.indel.hg38.vcf.gz")
     files+=("GRCh38/spliceai_scores.masked.indel.hg38.vcf.gz.tbi")
     files+=("GRCh38/spliceai_scores.masked.snv.hg38.vcf.gz")

--- a/modules/vcf/templates/annotate.sh
+++ b/modules/vcf/templates/annotate.sh
@@ -72,7 +72,7 @@ capice_vep() {
   args+=("--dir_plugins" "!{params.vcf.annotate.vep_plugin_dir}")
   args+=("--plugin" "SpliceAI,snv=!{vepPluginSpliceAiSnvPath},indel=!{vepPluginSpliceAiIndelPath}")
   args+=("--plugin" "Grantham")
-  args+=("--custom" "!{vepCustomPhyloPPath},phyloP,bigwig,exact,0")
+  args+=("--custom" "!{vepCustomPhyloPPath},phyloP,bed,exact,0")
 
   ${CMD_VEP} "${args[@]}"
 }
@@ -146,7 +146,7 @@ vep() {
   args+=("--plugin" "SpliceAI,snv=!{vepPluginSpliceAiSnvPath},indel=!{vepPluginSpliceAiIndelPath}")
   args+=("--plugin" "Capice,${capiceOutputPath}")
   args+=("--plugin" "UTRannotator,!{vepPluginUtrAnnotatorPath}")
-  args+=("--custom" "!{vepCustomPhyloPPath},phyloP,bigwig,exact,0")
+  args+=("--custom" "!{vepCustomPhyloPPath},phyloP,bed,exact,0")
   args+=("--safe")
 
   if [ -n "!{hpoIds}" ]; then

--- a/utils/convert_phylop_to_bed.txt
+++ b/utils/convert_phylop_to_bed.txt
@@ -1,0 +1,6 @@
+# workaround for https://github.com/Ensembl/ensembl-vep/issues/1414
+bigWigToWig hg19.100way.phyloP100way.bw hg19.100way.phyloP100way.wig
+wig2bed < hg19.100way.phyloP100way.wig > hg19.100way.phyloP100way_5cols.bed
+cut -f1-3,5 hg19.100way.phyloP100way_5cols.bed > hg19.100way.phyloP100way.bed
+bgzip hg19.100way.phyloP100way.bed
+tabix -p bed hg19.100way.phyloP100way.bed.gz


### PR DESCRIPTION
```
executing tests ...
PASSED gvcf
PASSED test_empty_input
PASSED test_empty_output_filter
PASSED test_empty_output_filter_samples
PASSED test_multiproject
PASSED test_multiproject_classify
PASSED test_corner_cases
PASSED test_snv_proband
PASSED test_snv_proband_trio
PASSED test_snv_proband_trio_sample_filtering
PASSED test_snv_proband_trio_b38
PASSED test_lp
PASSED test_lp_b38
PASSED test_lb
PASSED test_lb_b38
all tests passed successfully
```  