### PR TITLE
Fix awk command in annotSV workaround

### DIFF
--- a/modules/vcf/templates/annotate.sh
+++ b/modules/vcf/templates/annotate.sh
@@ -30,7 +30,7 @@ annot_sv() {
   elif [[ "!{meta.assembly}" == "GRCh38" ]]; then
     # workaround for https://github.com/lgmgeo/AnnotSV/issues/152 that might fail for some chromosomes e.g. GRCh37 MT maps to GRCh38 chrM)
     mv "!{vcf}.tsv" "!{vcf}.tsv.tmp"
-    awk -v FS='\t' -v OFS='\t' 'NR>1 {$2 = "chr"$2; print} 1' "!{vcf}.tsv.tmp" > "!{vcf}.tsv"
+    awk -v FS='\t' -v OFS='\t' 'NR>1 {$2 = "chr"$2} 1' "!{vcf}.tsv.tmp" > "!{vcf}.tsv"
   fi
 }
 


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [nvt] Updated documentation 

PASSED gvcf
PASSED test_empty_input
PASSED test_empty_output_filter
PASSED test_empty_output_filter_samples
PASSED test_multiproject
PASSED test_multiproject_classify
PASSED test_corner_cases
PASSED test_snv_proband
PASSED test_snv_proband_trio
PASSED test_snv_proband_trio_sample_filtering
PASSED test_snv_proband_trio_b38
PASSED test_lp
PASSED test_lp_b38
PASSED test_lb
PASSED test_lb_b38
