### PR TITLE
Update apptainer cmd for vip-report 5.4.0

### DIFF
--- a/config/nxf_vcf.config
+++ b/config/nxf_vcf.config
@@ -9,7 +9,7 @@ env {
   CMD_FILTERVEP = "apptainer exec --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vep-109.3.sif filter_vep"
   CMD_BGZIP = "apptainer exec --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vep-109.3.sif bgzip"
   CMD_SAMTOOLS= "apptainer exec --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/samtools-1.17-patch1.sif samtools"
-  CMD_VCFREPORT="apptainer exec --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-report-5.3.0.sif"
+  CMD_VCFREPORT="apptainer exec --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-report-5.4.0.sif"
   CMD_VCFDECISIONTREE = "apptainer exec --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-decision-tree-3.5.4.sif"
   CMD_VCFINHERITANCEMATCHER = "apptainer exec --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-inheritance-matcher-2.1.6.sif"
 


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [x] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 

bash ./test_vcf.sh
executing tests ...
PASSED gvcf
PASSED test_empty_input
PASSED test_empty_output_filter
PASSED test_empty_output_filter_samples
PASSED test_multiproject
PASSED test_multiproject_classify
PASSED test_corner_cases
PASSED test_snv_proband
PASSED test_snv_proband_trio
PASSED test_snv_proband_trio_sample_filtering
PASSED test_snv_proband_trio_b38
PASSED test_lp
PASSED test_lp_b38
PASSED test_lb
PASSED test_lb_b38
all tests passed successfully