### PR TITLE
bump vcf-report-5.4.0 to vcf-report-5.4.1

### DIFF
--- a/config/nxf.config
+++ b/config/nxf.config
@@ -1,5 +1,5 @@
 env {
-  VIP_VERSION = "5.7.0"
+  VIP_VERSION = "5.7.1"
 
   TMPDIR = "\${TMPDIR:-\${NXF_TEMP:-\$(mktemp -d)}}"
   APPTAINER_BIND = "${APPTAINER_BIND}"

--- a/config/nxf_vcf.config
+++ b/config/nxf_vcf.config
@@ -10,7 +10,7 @@ env {
   CMD_FILTERVEP = "apptainer exec --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vep-109.3.sif filter_vep"
   CMD_BGZIP = "apptainer exec --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vep-109.3.sif bgzip"
   CMD_SAMTOOLS= "apptainer exec --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/samtools-1.17-patch1.sif samtools"
-  CMD_VCFREPORT="apptainer exec --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-report-5.4.0.sif"
+  CMD_VCFREPORT="apptainer exec --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-report-5.4.1.sif"
   CMD_VCFDECISIONTREE = "apptainer exec --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-decision-tree-3.5.4.sif"
   CMD_VCFINHERITANCEMATCHER = "apptainer exec --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-inheritance-matcher-2.1.6.sif"
 

--- a/install.sh
+++ b/install.sh
@@ -200,7 +200,7 @@ download_images() {
   files+=("samtools-1.17-patch1.sif")
   files+=("vcf-decision-tree-3.5.4.sif")
   files+=("vcf-inheritance-matcher-2.1.6.sif")
-  files+=("vcf-report-5.4.0.sif")
+  files+=("vcf-report-5.4.1.sif")
   files+=("vep-109.3.sif")
   files+=("manta-1.6.0.sif")
 

--- a/utils/apptainer/build.sh
+++ b/utils/apptainer/build.sh
@@ -90,7 +90,7 @@ main() {
   images+=("samtools-1.17-patch1")
   images+=("vcf-decision-tree-3.5.4")
   images+=("vcf-inheritance-matcher-2.1.6")
-  images+=("vcf-report-5.4.0")
+  images+=("vcf-report-5.4.1")
   images+=("manta-1.6.0")
   
   for i in "${!images[@]}"; do

--- a/utils/apptainer/def/vcf-report-5.4.1.def
+++ b/utils/apptainer/def/vcf-report-5.4.1.def
@@ -8,7 +8,7 @@ From: sif/build/openjdk-17.sif
 %post
     version_major=5
     version_minor=4
-    version_patch=0
+    version_patch=1
 
     # install
     apk update
@@ -16,7 +16,7 @@ From: sif/build/openjdk-17.sif
 
     mkdir -p /opt/vcf-report/lib
     curl -Ls -o /opt/vcf-report/lib/vcf-report.jar "https://github.com/molgenis/vip-report/releases/download/v${version_major}.${version_minor}.${version_patch}/vcf-report.jar"
-    echo "299865de4cd71fd3ae50edccd36609ec360f1caf246a4554658903270f33d9aa  /opt/vcf-report/lib/vcf-report.jar" | sha256sum -c
+    echo "71fe0413efc63983e8ca3dfbd6c0d9957054b36672b191a09f0848d4a7afe654  /opt/vcf-report/lib/vcf-report.jar" | sha256sum -c
 
     # cleanup
     apk del .build-dependencies


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 
