### PR TITLE
bump vcf-report to 5.5.1, fix project_id param documentation

### DIFF
--- a/config/nxf.config
+++ b/config/nxf.config
@@ -1,5 +1,5 @@
 env {
-  VIP_VERSION = "5.7.2"
+  VIP_VERSION = "5.8.0"
 
   TMPDIR = "\${TMPDIR:-\${NXF_TEMP:-\$(mktemp -d)}}"
   APPTAINER_BIND = "${APPTAINER_BIND}"

--- a/config/nxf_vcf.config
+++ b/config/nxf_vcf.config
@@ -11,7 +11,7 @@ env {
   CMD_FILTERVEP = "apptainer exec --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vep-109.3.sif filter_vep"
   CMD_BGZIP = "apptainer exec --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vep-109.3.sif bgzip"
   CMD_SAMTOOLS= "apptainer exec --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/samtools-1.17-patch1.sif samtools"
-  CMD_VCFREPORT="apptainer exec --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-report-5.5.0.sif"
+  CMD_VCFREPORT="apptainer exec --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-report-5.5.1.sif"
   CMD_VCFDECISIONTREE = "apptainer exec --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-decision-tree-3.5.4.sif"
   CMD_VCFINHERITANCEMATCHER = "apptainer exec --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-inheritance-matcher-2.1.6.sif"
 

--- a/docs/usage/input.md
+++ b/docs/usage/input.md
@@ -23,19 +23,19 @@ Sample-sheet values are case sensitive. Columns can contain values of different 
 The following sections describe the columns that can be used in every sample-sheet followed by [workflow](workflow.md) specific columns.   
 
 ## Columns
-| column                | type            | required | default                 | description                             |                                        
-|-----------------------|-----------------|----------|-------------------------|-----------------------------------------|
-| ``project_id``        | ``string``      |          | ``vip``                 | project identifier                      |
-| ``family_id``         | ``string``      |          | ``vip_fam<index>``      | family identifier                       |
-| ``individual_id``     | ``string``      | yes      |                         | sample identifier of the individual     |
-| ``paternal_id``       | ``string``      |          |                         | sample identifier of the father         |
-| ``maternal_id``       | ``string``      |          |                         | sample identifier of the mother         |
-| ``sex``               | ``enum``        |          | unknown sex             | ``values: [male,female]``               |
-| ``affected``          | ``boolean``     |          | unknown affected status | whether the individual is affected      |
-| ``proband``           | ``boolean``     |          | depends<sup>1</sup>     | individual being reported on            |
-| ``hpo_ids``           | ``string list`` |          |                         | regex: `/HP:\d{7}/`                     |
-| ``assembly``          | ``enum``        |          | ``GRCh38``              | allowed values: [``GRCh37``,``GRCh38``] |
-| ``sequencing_method`` | ``enum``        |          | ``WGS``                 | allowed values: [``WES``,``WGS``]       |
+| column                | type            | required | default                 | description                                                  |                                        
+|-----------------------|-----------------|----------|-------------------------|--------------------------------------------------------------|
+| ``project_id``        | ``string``      |          | ``vip``                 | project identifier, see [here](../examples/multi-project.md) |
+| ``family_id``         | ``string``      |          | ``vip_fam<index>``      | family identifier                                            |
+| ``individual_id``     | ``string``      | yes      |                         | sample identifier of the individual                          |
+| ``paternal_id``       | ``string``      |          |                         | sample identifier of the father                              |
+| ``maternal_id``       | ``string``      |          |                         | sample identifier of the mother                              |
+| ``sex``               | ``enum``        |          | unknown sex             | ``values: [male,female]``                                    |
+| ``affected``          | ``boolean``     |          | unknown affected status | whether the individual is affected                           |
+| ``proband``           | ``boolean``     |          | depends<sup>1</sup>     | individual being reported on                                 |
+| ``hpo_ids``           | ``string list`` |          |                         | regex: `/HP:\d{7}/`                                          |
+| ``assembly``          | ``enum``        |          | ``GRCh38``              | allowed values: [``GRCh37``,``GRCh38``]                      |
+| ``sequencing_method`` | ``enum``        |          | ``WGS``                 | allowed values: [``WES``,``WGS``]                            |
 
 <sup>1</sup> Exception: if no probands are defined in the sample-sheet then all samples are considered to be probands.
 

--- a/docs/usage/input.md
+++ b/docs/usage/input.md
@@ -45,15 +45,15 @@ The following sections describe the columns that can be used in every sample-she
 | ``fastq``               | ``file list`` | yes<sup>2</sup> |              | allowed file extensions: [``fastq``, ``fastq.gz``, ``fq``, ``fq.gz``]. single-reads file(s)        |
 | ``fastq_r1``            | ``file list`` | yes<sup>2</sup> |              | allowed file extensions: [``fastq``, ``fastq.gz``, ``fq``, ``fq.gz``]. paired-end reads file(s) #1 |
 | ``fastq_r2``            | ``file list`` | yes<sup>2</sup> |              | allowed file extensions: [``fastq``, ``fastq.gz``, ``fq``, ``fq.gz``]. paired-end reads file(s) #2 |
-| ``sequencing_platform`` | ``enum``      |                 | ``illumina`` | allowed values: [``illumina``,``nanopore``,``pacbio_hifi``]                                                        |
+| ``sequencing_platform`` | ``enum``      |                 | ``illumina`` | allowed values: [``illumina``,``nanopore``,``pacbio_hifi``]                                        |
 
 <sup>2</sup> Either the `fastq` or the ``fastq_r1`` and ``fastq_r2`` are required.  
 
 ## Columns: CRAM
-| column                  | type     | required | default      | description                                  |
-|-------------------------|----------|----------|--------------|----------------------------------------------|
-| ``cram``                | ``file`` | yes      |              | allowed file extensions: [``bam``, ``cram``] |
-| ``sequencing_platform`` | ``enum`` |          | ``illumina`` | allowed values: [``illumina``,``nanopore``,``pacbio_hifi``]  |
+| column                  | type     | required | default      | description                                                 |
+|-------------------------|----------|----------|--------------|-------------------------------------------------------------|
+| ``cram``                | ``file`` | yes      |              | allowed file extensions: [``bam``, ``cram``]                |
+| ``sequencing_platform`` | ``enum`` |          | ``illumina`` | allowed values: [``illumina``,``nanopore``,``pacbio_hifi``] |
 
 ## Columns: VCF
 | column   | type     | required | default | description                                                                                   |

--- a/install.sh
+++ b/install.sh
@@ -222,7 +222,7 @@ download_images() {
   files+=("samtools-1.17-patch1.sif")
   files+=("vcf-decision-tree-3.5.4.sif")
   files+=("vcf-inheritance-matcher-2.1.6.sif")
-  files+=("vcf-report-5.5.0.sif")
+  files+=("vcf-report-5.5.1.sif")
   files+=("vep-109.3.sif")
   files+=("manta-1.6.0.sif")
   files+=("gado-1.0.1.sif")

--- a/utils/apptainer/build.sh
+++ b/utils/apptainer/build.sh
@@ -91,7 +91,7 @@ main() {
   images+=("samtools-1.17-patch1")
   images+=("vcf-decision-tree-3.5.4")
   images+=("vcf-inheritance-matcher-2.1.6")
-  images+=("vcf-report-5.5.0")
+  images+=("vcf-report-5.5.1")
   images+=("manta-1.6.0")
   
   for i in "${!images[@]}"; do

--- a/utils/apptainer/def/vcf-report-5.5.1.def
+++ b/utils/apptainer/def/vcf-report-5.5.1.def
@@ -8,7 +8,7 @@ From: sif/build/openjdk-17.sif
 %post
     version_major=5
     version_minor=5
-    version_patch=0
+    version_patch=1
 
     # install
     apk update
@@ -16,7 +16,7 @@ From: sif/build/openjdk-17.sif
 
     mkdir -p /opt/vcf-report/lib
     curl -Ls -o /opt/vcf-report/lib/vcf-report.jar "https://github.com/molgenis/vip-report/releases/download/v${version_major}.${version_minor}.${version_patch}/vcf-report.jar"
-    echo "71b3651e1b8ca5e0bb6ba2dd1349bfbf5867080690f0f53bdb1cc465f3781d76  /opt/vcf-report/lib/vcf-report.jar" | sha256sum -c
+    echo "791302158bf4b87faf6415011afb62efcd2225f42c635e7fd05bc8181fb3bead  /opt/vcf-report/lib/vcf-report.jar" | sha256sum -c
 
     # cleanup
     apk del .build-dependencies


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 
