### PR TITLE
Add default error strategy with backoff

### DIFF
--- a/config/nxf.config
+++ b/config/nxf.config
@@ -14,6 +14,9 @@ env {
 }
 
 process {
+  errorStrategy = { sleep(Math.pow(2, task.attempt) * 500 as long); return 'retry' }
+  maxRetries = 3
+
   cpus = 4
   memory = '4GB'
   time = '4h'

--- a/config/nxf.config
+++ b/config/nxf.config
@@ -14,9 +14,6 @@ env {
 }
 
 process {
-  errorStrategy = { sleep(Math.pow(2, task.attempt) * 500 as long); return 'retry' }
-  maxRetries = 3
-
   cpus = 4
   memory = '4GB'
   time = '4h'
@@ -29,6 +26,9 @@ profiles {
 
   slurm {
     process.executor = 'slurm'
+    errorStrategy = { task.exitStatus in [9, 143, 137, 104, 134, 139, 247] ? 'retry' : 'finish' }
+    maxErrors = '-1'
+    maxRetries = 3
   }
 }
 


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 
