### PR TITLE
bump vcf-inheritance-matcher 2.1.6 to 2.1.7

### DIFF
--- a/config/nxf_vcf.config
+++ b/config/nxf_vcf.config
@@ -9,7 +9,7 @@ env {
   CMD_STRANGER = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/stranger-0.8.1.sif stranger"
   CMD_VCFREPORT="apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-report-5.5.2.sif"
   CMD_VCFDECISIONTREE = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-decision-tree-3.5.4.sif"
-  CMD_VCFINHERITANCEMATCHER = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-inheritance-matcher-2.1.6.sif"
+  CMD_VCFINHERITANCEMATCHER = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-inheritance-matcher-2.1.7.sif"
 
   // workaround for SAMtools https://github.com/samtools/samtools/issues/1366#issuecomment-769170935
   REF_PATH = ":"

--- a/install.sh
+++ b/install.sh
@@ -227,7 +227,7 @@ download_images() {
   files+=("stranger-0.8.1.sif")
   files+=("straglr-philres-1.3.1.sif")
   files+=("vcf-decision-tree-3.5.4.sif")
-  files+=("vcf-inheritance-matcher-2.1.6.sif")
+  files+=("vcf-inheritance-matcher-2.1.7.sif")
   files+=("vcf-report-5.5.2.sif")
   files+=("vep-109.3.sif")
   files+=("manta-1.6.0.sif")

--- a/utils/apptainer/build.sh
+++ b/utils/apptainer/build.sh
@@ -92,7 +92,7 @@ main() {
   images+=("stranger-0.8.1")
   images+=("straglr-philres-1.3.1")
   images+=("vcf-decision-tree-3.5.4")
-  images+=("vcf-inheritance-matcher-2.1.6")
+  images+=("vcf-inheritance-matcher-2.1.7")
   images+=("vcf-report-5.5.2")
   images+=("manta-1.6.0")
   

--- a/utils/apptainer/def/vcf-inheritance-matcher-2.1.7.def
+++ b/utils/apptainer/def/vcf-inheritance-matcher-2.1.7.def
@@ -8,7 +8,7 @@ From: sif/build/openjdk-17.sif
 %post
     version_major=2
     version_minor=1
-    version_patch=6
+    version_patch=7
 
     # install
     apk update
@@ -16,7 +16,7 @@ From: sif/build/openjdk-17.sif
 
     mkdir -p /opt/vcf-inheritance-matcher/lib
     curl -Ls -o /opt/vcf-inheritance-matcher/lib/vcf-inheritance-matcher.jar "https://github.com/molgenis/vip-inheritance-matcher/releases/download/v${version_major}.${version_minor}.${version_patch}/vcf-inheritance-matcher.jar"
-    echo "47b64ca065ea8aa90ff8c7eda66279275ef4ebd52970c9caf63bcf8483ddbe43  /opt/vcf-inheritance-matcher/lib/vcf-inheritance-matcher.jar" | sha256sum -c
+    echo "894886fbeb462918ff87439f2a1852d803d15327e32b00395d41043c4d981323  /opt/vcf-inheritance-matcher/lib/vcf-inheritance-matcher.jar" | sha256sum -c
 
     # cleanup
     apk del .build-dependencies


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 
