### PR TITLE
fix GADO VEP plugin: NPE in print statement

### DIFF
--- a/resources/vep/plugins/GADO.pm
+++ b/resources/vep/plugins/GADO.pm
@@ -98,7 +98,6 @@ sub run {
     return {} unless $entrez_gene_id;
     my $ensembl_gene_id = $gene_mapping{$entrez_gene_id};
     unless ($ensembl_gene_id){
-        print "WARNING: No Entrez gene ID mapping found for Ensembl ID '$ensembl_gene_id'.";
         return {};
     }
     my $result;


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 
