### PR TITLE
Fix VEP plugins returning () instead of {}

### DIFF
--- a/resources/vep/plugins/AnnotSV.pm
+++ b/resources/vep/plugins/AnnotSV.pm
@@ -159,7 +159,7 @@ sub create_key {
 sub run {
     my ($self, $bvfoa) = @_;
     my %indices = %{$self->{indices}};
-    my $result = ();
+    my $result = {};
     my $annotations;
 
     my $svf = $bvfoa->base_variation_feature;

--- a/resources/vep/plugins/Capice.pm
+++ b/resources/vep/plugins/Capice.pm
@@ -166,7 +166,7 @@ sub run {
 
     my $key = create_key($chr,$pos,$ref,$alt,$gene,$source,$feature_type,$transcript_id);
 
-    my $result = ();
+    my $result = {};
     $result->{CAPICE_SC} = undef;
     $result->{CAPICE_CL} = undef;
     my $value = $self->{capice_map}{$key};

--- a/resources/vep/plugins/VKGL.pm
+++ b/resources/vep/plugins/VKGL.pm
@@ -268,7 +268,7 @@ sub run {
     my $alt = $vcf_line[4];
     my $gene_id = $transcript->{_gene_stable_id};
 
-    my $result = ();
+    my $result = {};
     if (!$self->{consensus_only}) {
         $result->{VKGL_AMC} = undef;
         $result->{VKGL_ERASMUS} = undef;


### PR DESCRIPTION
This leads to loss of data from VEP if an empty result is returned by the plugin


End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 
