### PR TITLE
Fix gitignore for vep plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,10 +10,13 @@
 /utils/apptainer/sif
 
 # Installed resource folders.
-/resources
+/resources/*
+!/resources/**/
+/resources/gado/
 !/resources/biomart_ensembl_entrez_mapping.txt
 !/resources/README.txt
 !/resources/decision_tree_*.json
+/resources/vep/cache
 !/resources/vep/plugins
 
 # test


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 
