### PR TITLE
fix #467 Report with long-read alignment hangs

### DIFF
--- a/modules/vcf/report.nf
+++ b/modules/vcf/report.nf
@@ -26,8 +26,9 @@ process report {
     maxSamples = params.vcf.report.max_samples
     genesPath = params.vcf.report[meta.project.assembly].genes
     template = params.vcf.report.template
-    crams = meta.crams ? meta.crams.collect { "${it.individual_id}=${it.cram}" }.join(",") : "" 
-    includeCrams = params.vcf.report.include_crams
+    crams = meta.crams ? meta.crams.collect { "${it.individual_id}=${it.cram}" }.join(",") : ""
+    // workaround for https://github.com/molgenis/vip/issues/467: genome browser hangs on long reads
+    includeCrams = meta.project.sequencing_platform !in ['nanopore', 'pacbio_hifi'] ? params.vcf.report.include_crams : false
 
     probands = meta.probands.collect{ proband -> proband.individual_id }.join(",")
     hpoIds = meta.project.samples.findAll{ sample -> !sample.hpo_ids.isEmpty() }.collect{ sample -> [sample.individual_id, sample.hpo_ids.join(";")].join("/") }.join(",") 


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 
