### PR TITLE
 Fix #471 cram_str_straglr_call can produce unsorted vcf

### DIFF
--- a/config/nxf_call_str.config
+++ b/config/nxf_call_str.config
@@ -2,7 +2,7 @@ includeConfig 'nxf.config'
 
 env {
   CMD_EXPANSIONHUNTER = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/expansionhunter-5.0.0.sif ExpansionHunter"
-  CMD_STRAGLR="apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/straglr-philres-1.3.1.sif straglr-genotype"
+  CMD_STRAGLR="apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/straglr-philres-1.4.2.sif straglr-genotype"
 }
 
 params {

--- a/install.sh
+++ b/install.sh
@@ -231,7 +231,7 @@ download_images() {
   files+=("minimap2-2.26.sif")
   files+=("samtools-1.17-patch1.sif")
   files+=("stranger-0.8.1.sif")
-  files+=("straglr-philres-1.3.1.sif")
+  files+=("straglr-philres-1.4.2.sif")
   files+=("vcf-decision-tree-3.7.0.sif")
   files+=("vcf-inheritance-matcher-2.1.8.sif")
   files+=("vcf-report-5.6.1.sif")

--- a/modules/cram/straglr.nf
+++ b/modules/cram/straglr.nf
@@ -9,6 +9,7 @@ process straglr_call {
     tuple val(meta), path(vcfOut), path(vcfOutIndex), path(vcfOutStats)
   shell:
     paramReference = params[meta.project.assembly].reference.fasta
+    paramReferenceFai = params[meta.project.assembly].reference.fastaFai
     paramLoci = params.str.straglr[meta.project.assembly].loci
     paramMinSupport = params.str.straglr.min_support
     paramMinClusterSize = params.str.straglr.min_cluster_size

--- a/modules/cram/templates/straglr_call.sh
+++ b/modules/cram/templates/straglr_call.sh
@@ -18,7 +18,9 @@ call_short_tandem_repeats () {
 }
 
 index () {
-  ${CMD_BCFTOOLS} view --no-version --threads "!{task.cpus}" --output-type z "straglr.vcf" > "!{vcfOut}"
+  # workaround for https://github.com/molgenis/vip/issues/471
+  ${CMD_BCFTOOLS} reheader --fai "!{paramReferenceFai}" --temp-prefix . --threads "!{task.cpus}" "straglr.vcf" | ${CMD_BCFTOOLS} sort --temp-dir . --max-mem "!{task.memory.toGiga() - 1}" --output-type z --output "!{vcfOut}"
+
   ${CMD_BCFTOOLS} index --csi --output "!{vcfOutIndex}" --threads "!{task.cpus}" "!{vcfOut}"
   ${CMD_BCFTOOLS} index --stats "!{vcfOut}" > "!{vcfOutStats}"
 

--- a/utils/apptainer/build.sh
+++ b/utils/apptainer/build.sh
@@ -91,7 +91,7 @@ main() {
   images+=("minimap2-2.26")
   images+=("samtools-1.17-patch1")
   images+=("stranger-0.8.1")
-  images+=("straglr-philres-1.3.1")
+  images+=("straglr-philres-1.4.2")
   images+=("vcf-decision-tree-3.7.0")
   images+=("vcf-inheritance-matcher-2.1.8")
   images+=("vcf-report-5.6.1")

--- a/utils/apptainer/def/straglr-philres-1.4.2.def
+++ b/utils/apptainer/def/straglr-philres-1.4.2.def
@@ -11,8 +11,8 @@ From: sif/build/ubuntu-22.04.sif
     curl -Ls -o /opt/trf/trf "https://github.com/Benson-Genomics-Lab/TRF/releases/download/v4.09.1/trf409.linux64"
     chmod +x /opt/trf/trf
 
-    # No tags present on repository, so the most recent version of the egg in always installed.
-    pip install git+https://github.com/philres/straglr.git#egg=straglr
+    # ce7d96cad4630d6a73114657e082f2402b1b1213 = v1.4.2
+    pip install git+https://github.com/philres/straglr.git@ce7d96cad4630d6a73114657e082f2402b1b1213#egg=straglr
 
     # cleanup
     pip cache purge


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 
