### PR TITLE
fix: revert removal of unzip_reference

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -304,6 +304,7 @@ main() {
   download_nextflow
   download_images
   download_resources "${assembly}"
+  unzip_reference "${assembly}"
   create_executable
   echo -e "installing done"
 }


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 
