### PR TITLE
Update annotate.nf: fix GADO

### DIFF
--- a/modules/vcf/annotate.nf
+++ b/modules/vcf/annotate.nf
@@ -31,7 +31,7 @@ process annotate {
     strangerCatalog = params.vcf.annotate[assembly].stranger_catalog
 
     areProbandHpoIdsIndentical = areProbandHpoIdsIndentical(meta.project.samples)
-    gadoScores = meta.gado
+    gadoScores = meta.gado != null ? meta.gado : ""
 
     template 'annotate.sh'
 


### PR DESCRIPTION
```
running tests ...
vcf/corner_cases                         | PASSED | 145571=completed output/vcf/corner_cases/.nxf.log
vcf/empty_input                          | PASSED | 145572=completed output/vcf/empty_input/.nxf.log
vcf/empty_output_filter_samples          | PASSED | 145573=completed output/vcf/empty_output_filter_samples/.nxf.log
vcf/empty_output_filter                  | PASSED | 145574=completed output/vcf/empty_output_filter/.nxf.log
vcf/lb_b38                               | PASSED | 145575=completed output/vcf/lb_b38/.nxf.log
vcf/lb                                   | PASSED | 145576=completed output/vcf/lb/.nxf.log
vcf/lp_b38                               | PASSED | 145577=completed output/vcf/lp_b38/.nxf.log
vcf/lp                                   | PASSED | 145578=completed output/vcf/lp/.nxf.log
vcf/multiproject_classify                | PASSED | 145579=completed output/vcf/multiproject_classify/.nxf.log
vcf/snv_proband                          | PASSED | 145580=completed output/vcf/snv_proband/.nxf.log
vcf/snv_proband_trio_b38                 | PASSED | 145581=completed output/vcf/snv_proband_trio_b38/.nxf.log
vcf/snv_proband_trio_sample_filtering    | PASSED | 145582=completed output/vcf/snv_proband_trio_sample_filtering/.nxf.log
vcf/snv_proband_trio                     | PASSED | 145583=completed output/vcf/snv_proband_trio/.nxf.log
done
```