### PR TITLE
Fix: non paired ended fastq split broken

### DIFF
--- a/modules/fastq/utils.nf
+++ b/modules/fastq/utils.nf
@@ -10,10 +10,12 @@ def splitPerFastqPaired(meta) {
 }
 
 def splitPerFastqSingle(meta) {
+    def index = 0;
     def meta_per_fastq = [];
     def total = meta.sample.fastq.size();
     for(fastq in meta.sample.fastq){
       meta_per_fastq.add([*:meta, sample: [*:meta.sample, fastq: [data: fastq, total: total, index: index]]])
+      index++;
     }
     return meta_per_fastq;
 }


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 
