### PR TITLE
split fastq for non paired ended test

### DIFF
--- a/test/suites/fastq/nanopore.sh
+++ b/test/suites/fastq/nanopore.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 # shellcheck disable=SC1091
 source "${TEST_UTILS_DIR}/utils.sh"
 
-download_test_resource "m54238_180628_014238_s0_10000.Q20.fastq.gz" "${TEST_RESOURCES_DIR}/downloads"
+download_test_resource "m54238_180628_014238_s0_10000.Q20.part_001.fastq.gz" "${TEST_RESOURCES_DIR}/downloads"
+download_test_resource "m54238_180628_014238_s0_10000.Q20.part_002.fastq.gz" "${TEST_RESOURCES_DIR}/downloads"
 
 args=()
 args+=("--workflow" "fastq")

--- a/test/suites/fastq/resources/nanopore.tsv
+++ b/test/suites/fastq/resources/nanopore.tsv
@@ -1,2 +1,2 @@
 individual_id	sequencing_platform	fastq
-HG002	nanopore	downloads/m54238_180628_014238_s0_10000.Q20.fastq.gz
+HG002	nanopore	downloads/m54238_180628_014238_s0_10000.Q20.part_001.fastq.gz,downloads/m54238_180628_014238_s0_10000.Q20.part_002.fastq.gz


### PR DESCRIPTION
```
fastq/nanopore                           | PASSED | 158487=completed output/fastq/nanopore/.nxf.log
```
