### PR TITLE
Run fixmate and sort parallel on crams

### DIFF
--- a/modules/fastq/templates/merge_cram.sh
+++ b/modules/fastq/templates/merge_cram.sh
@@ -5,36 +5,25 @@ merge(){
     IFS=' ' read -a cram_array <<< "!{crams}";
     if [ ${#cram_array} -gt 1 ]
     then
-        ${CMD_SAMTOOLS} merge -@ "!{task.cpus}" -o "unmarked_!{cramOut}" --write-index !{crams}
-    else
-        # include single crams in the merge process to include them in the publish
-        cp !{crams} "unmarked_!{cramOut}"
+        ${CMD_SAMTOOLS} merge -@ "!{task.cpus}" -o "!{cramOut}" --write-index !{crams}
     fi
 }
 
 mark_dups(){
-    if [ "!{isPairEnded}" == "true" ]
+    if [[ "!{platform}" != "nanopore" ]]
     then
-        #name sort for fixmate
-        ${CMD_SAMTOOLS} sort -n -@ "!{task.cpus}" -o - "unmarked_!{cramOut}" | \
-        ${CMD_SAMTOOLS} fixmate -u -m -@ "!{task.cpus}" - - | \
-        #position sort for markdup
-        ${CMD_SAMTOOLS} sort -u -@ "!{task.cpus}" - | \
-        ${CMD_SAMTOOLS} markdup -@ "!{task.cpus}" --reference "!{reference}" --write-index - "!{cramOut}"
-    else
-        if [[ "!{platform}" == "nanopore" ]]; then
-            ${CMD_SAMTOOLS} sort -u -@ "!{task.cpus}" --reference "!{reference}" -o "!{cramOut}" --write-index "unmarked_!{cramOut}"
-        else
-            ${CMD_SAMTOOLS} sort -u -@ "!{task.cpus}" "unmarked_!{cramOut}" | \
-            ${CMD_SAMTOOLS} markdup -@ "!{task.cpus}" --reference "!{reference}" --write-index - "!{cramOut}"
-        fi
+        mv "!{cramOut}" "unmarked_!{cramOut}"
+        ${CMD_SAMTOOLS} markdup -@ "!{task.cpus}" --reference "!{reference}" --write-index "unmarked_!{cramOut}" "!{cramOut}"
     fi
 
     ${CMD_SAMTOOLS} idxstats "!{cramOut}" > "!{cramOutStats}"
 }
 
 cleanup(){
-    rm unmarked_!{cramOut}
+    if [[ "!{platform}" != "nanopore" ]]
+    then
+        rm unmarked_!{cramOut}
+    fi
 }
 
 main() {

--- a/modules/fastq/templates/minimap2_align_paired_end.sh
+++ b/modules/fastq/templates/minimap2_align_paired_end.sh
@@ -14,7 +14,10 @@ align() {
     args+=("!{referenceMmi}")
     args+=("!{fastqR1}" "!{fastqR2}") 
 
-    ${CMD_MINIMAP2} "${args[@]}" | ${CMD_SAMTOOLS} sort -u -@ "!{task.cpus}" --reference "!{reference}" -o "!{cram}" --write-index -
+    ${CMD_MINIMAP2} "${args[@]}" | \
+    ${CMD_SAMTOOLS} fixmate -u -m -@ "!{task.cpus}" - - | \
+    #position sort for markdup
+    ${CMD_SAMTOOLS} sort -u -@ "!{task.cpus}" -o "!{cram}" --write-index -
 }
 
 stats() {

--- a/modules/fastq/templates/minimap2_align_paired_end.sh
+++ b/modules/fastq/templates/minimap2_align_paired_end.sh
@@ -15,9 +15,9 @@ align() {
     args+=("!{fastqR1}" "!{fastqR2}") 
 
     ${CMD_MINIMAP2} "${args[@]}" | \
-    ${CMD_SAMTOOLS} fixmate -u -m -@ "!{task.cpus}" - - | \
+    ${CMD_SAMTOOLS} fixmate --no-PG -u -m -@ "!{task.cpus}" - - | \
     #position sort for markdup
-    ${CMD_SAMTOOLS} sort -u -@ "!{task.cpus}" -o "!{cram}" --write-index -
+    ${CMD_SAMTOOLS} sort --no-PG -u -@ "!{task.cpus}" --reference "!{reference}" -o "!{cram}" --write-index -
 }
 
 stats() {


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 

fastq/nanopore | PASSED |
fastq/pacbio_hifi | PASSED |

manual paired end - multi file per pair - test is now @ variant calling, so past the point of these changes