### PR TITLE
update Nextflow 23.04.1 to 23.10.0

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -36,7 +36,7 @@ download() {
 }
 
 download_nextflow() {
-  local -r version="23.04.1"
+  local -r version="23.10.0"
   local -r file="nextflow-${version}-all"
   local -r download_dir="${SCRIPT_DIR}"
 

--- a/vip.sh
+++ b/vip.sh
@@ -140,7 +140,7 @@ execute_workflow() {
   if [[ "${paramStub}" == "true" ]]; then
     args+=("-stub")
   fi
-  (cd "${paramOutput}" && APPTAINER_BIND="${APPTAINER_BIND-${envBind}}" APPTAINER_CACHEDIR="${envCacheDir}" NXF_VER="23.04.1" NXF_HOME="${envHome}" NXF_TEMP="${envTemp}" NXF_WORK="${envWork}" NXF_ENABLE_STRICT="${envStrict}" "${VIP_DIR}/nextflow" "${args[@]}")
+  (cd "${paramOutput}" && APPTAINER_BIND="${APPTAINER_BIND-${envBind}}" APPTAINER_CACHEDIR="${envCacheDir}" NXF_VER="23.10.0" NXF_HOME="${envHome}" NXF_TEMP="${envTemp}" NXF_WORK="${envWork}" NXF_ENABLE_STRICT="${envStrict}" "${VIP_DIR}/nextflow" "${args[@]}")
 }
 
 main() {


### PR DESCRIPTION
```
running tests ...
vcf/corner_cases                         | PASSED | 159383=completed test/output/vcf/corner_cases/.nxf.log
vcf/empty_input                          | PASSED | 159384=completed test/output/vcf/empty_input/.nxf.log
vcf/empty_output_filter_samples          | PASSED | 159385=completed test/output/vcf/empty_output_filter_samples/.nxf.log
vcf/empty_output_filter                  | PASSED | 159386=completed test/output/vcf/empty_output_filter/.nxf.log
vcf/lb_b38                               | PASSED | 159387=completed test/output/vcf/lb_b38/.nxf.log
vcf/lb                                   | PASSED | 159388=completed test/output/vcf/lb/.nxf.log
vcf/lp_b38                               | PASSED | 159389=completed test/output/vcf/lp_b38/.nxf.log
vcf/lp                                   | PASSED | 159390=completed test/output/vcf/lp/.nxf.log
vcf/multiproject_classify                | PASSED | 159391=completed test/output/vcf/multiproject_classify/.nxf.log
vcf/snv_proband                          | PASSED | 159392=completed test/output/vcf/snv_proband/.nxf.log
vcf/snv_proband_trio_b38                 | PASSED | 159393=completed test/output/vcf/snv_proband_trio_b38/.nxf.log
vcf/snv_proband_trio_sample_filtering    | PASSED | 159394=completed test/output/vcf/snv_proband_trio_sample_filtering/.nxf.log
vcf/snv_proband_trio                     | PASSED | 159395=completed test/output/vcf/snv_proband_trio/.nxf.log
done
```