### PR TITLE
update ClinVar 20230910 to 20231104

### DIFF
--- a/config/nxf_vcf.config
+++ b/config/nxf_vcf.config
@@ -66,7 +66,7 @@ params {
         stranger_catalog = "${projectDir}/resources/GRCh37/variant_catalog_grch37_fixed.json"
         // workaround for https://github.com/Ensembl/ensembl-vep/issues/1414
         vep_custom_phylop = "${projectDir}/resources/GRCh37/hg19.100way.phyloP100way.bed.gz"
-        vep_plugin_clinvar = "${projectDir}/resources/GRCh37/clinvar_20230910_stripped.tsv.gz"
+        vep_plugin_clinvar = "${projectDir}/resources/GRCh37/clinvar_20231104_stripped.tsv.gz"
         vep_plugin_gnomad = "${projectDir}/resources/GRCh37/gnomad.total.r2.1.1.sites.stripped.patch1.tsv.gz"
         vep_plugin_spliceai_indel = "${projectDir}/resources/GRCh37/spliceai_scores.masked.indel.hg19.vcf.gz"
         vep_plugin_spliceai_snv = "${projectDir}/resources/GRCh37/spliceai_scores.masked.snv.hg19.vcf.gz"
@@ -82,7 +82,7 @@ params {
         stranger_catalog = "${projectDir}/resources/GRCh38/variant_catalog_grch38_fixed.json"
         // workaround for https://github.com/Ensembl/ensembl-vep/issues/1414
         vep_custom_phylop = "${projectDir}/resources/GRCh38/hg38.phyloP100way.bed.gz"
-        vep_plugin_clinvar = "${projectDir}/resources/GRCh38/clinvar_20230910_stripped.tsv.gz"
+        vep_plugin_clinvar = "${projectDir}/resources/GRCh38/clinvar_20231104_stripped.tsv.gz"
         vep_plugin_gnomad = "${projectDir}/resources/GRCh38/gnomad.genomes.v3.1.2.sites.stripped.tsv.gz"
         vep_plugin_spliceai_indel = "${projectDir}/resources/GRCh38/spliceai_scores.masked.indel.hg38.vcf.gz"
         vep_plugin_spliceai_snv = "${projectDir}/resources/GRCh38/spliceai_scores.masked.snv.hg38.vcf.gz"

--- a/install.sh
+++ b/install.sh
@@ -53,8 +53,8 @@ download_resources_molgenis() {
 
   if [ "${assembly}" == "ALL" ] || [ "${assembly}" == "GRCh37" ]; then
     files+=("GRCh37/capice_model_v5.1.1-v1.ubj")
-    files+=("GRCh37/clinvar_20230910_stripped.tsv.gz")
-    files+=("GRCh37/clinvar_20230910_stripped.tsv.gz.tbi")
+    files+=("GRCh37/clinvar_20231104_stripped.tsv.gz")
+    files+=("GRCh37/clinvar_20231104_stripped.tsv.gz.tbi")
     files+=("GRCh37/expansionhunter_variant_catalog.json")
     files+=("GRCh37/variant_catalog_grch37_fixed.json")
     files+=("GRCh37/GCF_000001405.25_GRCh37.p13_genomic_g1k.gff.gz")
@@ -85,8 +85,8 @@ download_resources_molgenis() {
   if [ "${assembly}" == "ALL" ] || [ "${assembly}" == "GRCh38" ]; then
     files+=("GRCh38/capice_model_v5.1.1-v1.ubj")
     files+=("GRCh38/clinical_repeats.bed")
-    files+=("GRCh38/clinvar_20230910_stripped.tsv.gz")
-    files+=("GRCh38/clinvar_20230910_stripped.tsv.gz.tbi")
+    files+=("GRCh38/clinvar_20231104_stripped.tsv.gz")
+    files+=("GRCh38/clinvar_20231104_stripped.tsv.gz.tbi")
     files+=("GRCh38/expansionhunter_variant_catalog.json")
     files+=("GRCh38/variant_catalog_grch38_fixed.json")
     files+=("GRCh38/GCA_000001405.15_GRCh38_no_alt_analysis_set.dict")


### PR DESCRIPTION
```
running tests ...
vcf/corner_cases                         | PASSED | 159875=completed test/output/vcf/corner_cases/.nxf.log
vcf/empty_input                          | PASSED | 159876=completed test/output/vcf/empty_input/.nxf.log
vcf/empty_output_filter_samples          | PASSED | 159877=completed test/output/vcf/empty_output_filter_samples/.nxf.log
vcf/empty_output_filter                  | PASSED | 159878=completed test/output/vcf/empty_output_filter/.nxf.log
vcf/lb_b38                               | PASSED | 159879=completed test/output/vcf/lb_b38/.nxf.log
vcf/lb                                   | PASSED | 159880=completed test/output/vcf/lb/.nxf.log
vcf/lp_b38                               | PASSED | 159881=completed test/output/vcf/lp_b38/.nxf.log
vcf/lp                                   | PASSED | 159882=completed test/output/vcf/lp/.nxf.log
vcf/multiproject_classify                | PASSED | 159883=completed test/output/vcf/multiproject_classify/.nxf.log
vcf/snv_proband                          | PASSED | 159884=completed test/output/vcf/snv_proband/.nxf.log
vcf/snv_proband_trio_b38                 | PASSED | 159885=completed test/output/vcf/snv_proband_trio_b38/.nxf.log
vcf/snv_proband_trio_sample_filtering    | PASSED | 159886=completed test/output/vcf/snv_proband_trio_sample_filtering/.nxf.log
vcf/snv_proband_trio                     | PASSED | 159887=completed test/output/vcf/snv_proband_trio/.nxf.log
done
```