### PR TITLE
fix sample sheet project validation

### DIFF
--- a/modules/sample_sheet.nf
+++ b/modules/sample_sheet.nf
@@ -94,7 +94,7 @@ def parseCommonSampleSheet(csvFilename, additionalCols) {
   def projects
   try {
     projects = parseProjects(samples, cols)
-    projects.each { project -> validate(project.samples)}
+    projects.each { project -> validate(project)}
   } catch(IllegalArgumentException e) {
     exit 1, "error parsing '${csvFilename}': ${e.message}"
   }
@@ -102,26 +102,26 @@ def parseCommonSampleSheet(csvFilename, additionalCols) {
   return projects
 }
 
-def validate(samples){
+def validate(project){
   def sampleMap = [:]
-  samples.each{ sample ->
-    if(sampleMap[[id: sample.individual_id, projectId: sample.project_id]] != null)  throw new IllegalArgumentException("line ${sample.index}: individual_id '${sample.individual_id}' already exists in project '${sample.project_id}', individual_id should be unique within a project.")
-    sampleMap[[id: sample.individual_id, projectId: sample.project_id]] = [projectId : sample.project_id, familyId : sample.family_id, sex: sample.sex]
+  project.samples.each{ sample ->
+    if(sampleMap[[id: sample.individual_id]] != null)  throw new IllegalArgumentException("line ${sample.index}: individual_id '${sample.individual_id}' already exists in project '${project.id}', individual_id should be unique within a project.")
+    sampleMap[[id: sample.individual_id]] = [familyId : sample.family_id, sex: sample.sex]
   }
-  samples.each{ sample ->
+  project.samples.each{ sample ->
     if(sample.paternal_id != null){
       if(sample.individual_id == sample.paternal_id) throw new IllegalArgumentException("line ${sample.index}: individual_id '${sample.individual_id}' cannot be the same as paternal_id '${sample.paternal_id}'")
 
-      def paternal_sample = sampleMap[[id: sample.paternal_id, projectId: sample.project_id]]
-      if(paternal_sample == null) throw new IllegalArgumentException("line ${sample.index}: paternal_id sample '${sample.paternal_id}' for sample '${sample.individual_id}' is not present in project '${sample.project_id}'.")
+      def paternal_sample = sampleMap[[id: sample.paternal_id]]
+      if(paternal_sample == null) throw new IllegalArgumentException("line ${sample.index}: paternal_id sample '${sample.paternal_id}' for sample '${sample.individual_id}' is not present in project '${project.id}'.")
       if(paternal_sample.familyId != sample.family_id) throw new IllegalArgumentException("line ${sample.index}: paternal_id sample '${sample.paternal_id}' for sample '${sample.individual_id}' belongs to a different family.")
       if(paternal_sample.sex == "female") throw new IllegalArgumentException("line ${sample.index}: paternal_id sample '${sample.paternal_id}' refers to sample with female sex.")
     }
     if(sample.maternal_id != null){
       if(sample.individual_id == sample.maternal_id) throw new IllegalArgumentException("line ${sample.index}: individual_id '${sample.individual_id}' cannot be the same as maternal_id '${sample.maternal_id}'")
 
-      def maternal_sample = sampleMap[[id: sample.maternal_id, projectId: sample.project_id]]
-      if(maternal_sample == null) throw new IllegalArgumentException("line ${sample.index}: maternal_id sample '${sample.maternal_id}' for sample '${sample.individual_id}' is not present in project '${sample.project_id}'.")
+      def maternal_sample = sampleMap[[id: sample.maternal_id]]
+      if(maternal_sample == null) throw new IllegalArgumentException("line ${sample.index}: maternal_id sample '${sample.maternal_id}' for sample '${sample.individual_id}' is not present in project '${project.id}'.")
       if(maternal_sample.familyId != sample.family_id) throw new IllegalArgumentException("line ${sample.index}: maternal_id sample '${sample.maternal_id}' for sample '${sample.individual_id}' belongs to a different family.")
       if(maternal_sample.sex == "male") throw new IllegalArgumentException("line ${sample.index}: maternal_id sample '${sample.maternal_id}' refers to sample with male sex.")
     }


### PR DESCRIPTION
create an error in `vcf/snv_proband_trio`:
```
running tests ...
vcf/snv_proband_trio_b38                 | PASSED | 160066=completed test/output/vcf/snv_proband_trio_b38/.nxf.log
vcf/snv_proband_trio_sample_filtering    | PASSED | 160067=completed test/output/vcf/snv_proband_trio_sample_filtering/.nxf.log
vcf/snv_proband_trio                     | KAPUTT | 160068=failed    test/output/vcf/snv_proband_trio/.nxf.log
done
```

```
Nov-09 14:52:43.809 [main] ERROR nextflow.Nextflow - error parsing '/groups/umcg-vipt/tmp05/projects/vip_validation/fix/samplesheet_validation/test/suites/vcf/resources/snv_proband_trio.tsv': line 1: maternal_id sample 'MOTHERx0' for sample 'PROBAND0' is not present in project 'vip'.
```
