### PR TITLE
bump inheritance matcher 2.1.8 to 2.1.9

### DIFF
--- a/config/nxf_vcf.config
+++ b/config/nxf_vcf.config
@@ -9,7 +9,7 @@ env {
   CMD_STRANGER = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/stranger-0.8.1.sif stranger"
   CMD_VCFREPORT="apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-report-5.6.1.sif"
   CMD_VCFDECISIONTREE = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-decision-tree-3.8.0.sif"
-  CMD_VCFINHERITANCEMATCHER = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-inheritance-matcher-2.1.8.sif"
+  CMD_VCFINHERITANCEMATCHER = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-inheritance-matcher-2.1.9.sif"
 
   // workaround for SAMtools https://github.com/samtools/samtools/issues/1366#issuecomment-769170935
   REF_PATH = ":"

--- a/install.sh
+++ b/install.sh
@@ -236,7 +236,7 @@ download_images() {
   files+=("stranger-0.8.1.sif")
   files+=("straglr-philres-1.4.2.sif")
   files+=("vcf-decision-tree-3.8.0.sif")
-  files+=("vcf-inheritance-matcher-2.1.8.sif")
+  files+=("vcf-inheritance-matcher-2.1.9.sif")
   files+=("vcf-report-5.6.1.sif")
   files+=("vep-109.3.sif")
 

--- a/utils/apptainer/build.sh
+++ b/utils/apptainer/build.sh
@@ -93,7 +93,7 @@ main() {
   images+=("stranger-0.8.1")
   images+=("straglr-philres-1.4.2")
   images+=("vcf-decision-tree-3.8.0")
-  images+=("vcf-inheritance-matcher-2.1.8")
+  images+=("vcf-inheritance-matcher-2.1.9")
   images+=("vcf-report-5.6.1")
 
   for i in "${!images[@]}"; do

--- a/utils/apptainer/def/vcf-inheritance-matcher-2.1.9.def
+++ b/utils/apptainer/def/vcf-inheritance-matcher-2.1.9.def
@@ -8,7 +8,7 @@ From: sif/build/openjdk-17.sif
 %post
     version_major=2
     version_minor=1
-    version_patch=8
+    version_patch=9
 
     # install
     apk update
@@ -16,7 +16,7 @@ From: sif/build/openjdk-17.sif
 
     mkdir -p /opt/vcf-inheritance-matcher/lib
     curl -Ls -o /opt/vcf-inheritance-matcher/lib/vcf-inheritance-matcher.jar "https://github.com/molgenis/vip-inheritance-matcher/releases/download/v${version_major}.${version_minor}.${version_patch}/vcf-inheritance-matcher.jar"
-    echo "d3cd72908245c7ed2cb3a25031fff48e9d07c38e76d966e02bc4848cdf151156  /opt/vcf-inheritance-matcher/lib/vcf-inheritance-matcher.jar" | sha256sum -c
+    echo "a5a698a383f6fd3c5d1952078ef8bcf290a4ac0e2cccabea878043ab0bb2bab4  /opt/vcf-inheritance-matcher/lib/vcf-inheritance-matcher.jar" | sha256sum -c
 
     # cleanup
     apk del .build-dependencies


### PR DESCRIPTION
```
running tests ...
vcf/snv_proband_trio_b38                 | PASSED | 160259=completed test/output/vcf/snv_proband_trio_b38/.nxf.log
vcf/snv_proband_trio_sample_filtering    | PASSED | 160260=completed test/output/vcf/snv_proband_trio_sample_filtering/.nxf.log
vcf/snv_proband_trio                     | PASSED | 160261=completed test/output/vcf/snv_proband_trio/.nxf.log
done
```