### PR TITLE
Bump/version thresholds

### DIFF
--- a/config/nxf.config
+++ b/config/nxf.config
@@ -1,5 +1,5 @@
 env {
-  VIP_VERSION = "6.2.0"
+  VIP_VERSION = "6.3.0"
 
   TMPDIR = "\${TMPDIR:-\${NXF_TEMP:-\$(mktemp -d)}}"
   APPTAINER_BIND = "${APPTAINER_BIND}"

--- a/test/suites/vcf/lb.sh
+++ b/test/suites/vcf/lb.sh
@@ -11,7 +11,7 @@ args+=("--resume")
 vip "${args[@]}" 1> /dev/null
 
 # compare expected to actual output and store result
-if [ ! "$(zcat "${OUTPUT_DIR}/vip.vcf.gz" | grep -vc "^#")" -gt 144 ]; then
+if [ ! "$(zcat "${OUTPUT_DIR}/vip.vcf.gz" | grep -vc "^#")" -gt 142 ]; then
   result="0"
 else
   result="1"

--- a/test/suites/vcf/lb_b38.sh
+++ b/test/suites/vcf/lb_b38.sh
@@ -11,7 +11,7 @@ args+=("--resume")
 vip "${args[@]}" 1> /dev/null
 
 # compare expected to actual output and store result
-if [ ! "$(zcat "${OUTPUT_DIR}/vip.vcf.gz" | grep -vc "^#")" -gt 151 ]; then
+if [ ! "$(zcat "${OUTPUT_DIR}/vip.vcf.gz" | grep -vc "^#")" -gt 148 ]; then
   result="0"
 else
   result="1"

--- a/test/suites/vcf/lp.sh
+++ b/test/suites/vcf/lp.sh
@@ -11,7 +11,7 @@ args+=("--resume")
 vip "${args[@]}" 1> /dev/null
 
 # compare expected to actual output and store result
-if [ ! "$(zcat "${OUTPUT_DIR}/vip.vcf.gz" | grep -vc "^#")" -lt 2301 ]; then
+if [ ! "$(zcat "${OUTPUT_DIR}/vip.vcf.gz" | grep -vc "^#")" -lt 2302 ]; then
   result="0"
 else
   result="1"

--- a/test/suites/vcf/lp_b38.sh
+++ b/test/suites/vcf/lp_b38.sh
@@ -11,7 +11,7 @@ args+=("--resume")
 vip "${args[@]}" 1> /dev/null
 
 # compare expected to actual output and store result
-if [ ! "$(zcat "${OUTPUT_DIR}/vip.vcf.gz" | grep -vc "^#")" -lt 2302 ]; then
+if [ ! "$(zcat "${OUTPUT_DIR}/vip.vcf.gz" | grep -vc "^#")" -lt 2304 ]; then
   result="0"
 else
   result="1"


### PR DESCRIPTION
```
running tests ...
cram/complex                             | PASSED | 160744=completed test/output/cram/complex/.nxf.log
cram/multiproject                        | PASSED | 160745=completed test/output/cram/multiproject/.nxf.log
cram/nanopore_duo                        | PASSED | 160746=completed test/output/cram/nanopore_duo/.nxf.log
cram/nanopore                            | PASSED | 160747=completed test/output/cram/nanopore/.nxf.log
cram/single                              | PASSED | 160748=completed test/output/cram/single/.nxf.log
cram/trio                                | PASSED | 160749=completed test/output/cram/trio/.nxf.log
fastq/nanopore                           | PASSED | 160750=completed test/output/fastq/nanopore/.nxf.log
fastq/pacbio_hifi                        | PASSED | 160751=completed test/output/fastq/pacbio_hifi/.nxf.log
giab/NA12878_illumina_hiseq_exome        | PASSED | 160752=completed test/output/giab/NA12878_illumina_hiseq_exome/.nxf.log
gvcf/multiproject                        | PASSED | 160753=completed test/output/gvcf/multiproject/.nxf.log
gvcf/trio                                | PASSED | 160754=completed test/output/gvcf/trio/.nxf.log
vcf/corner_cases                         | PASSED | 160755=completed test/output/vcf/corner_cases/.nxf.log
vcf/empty_input                          | PASSED | 160756=completed test/output/vcf/empty_input/.nxf.log
vcf/empty_output_filter_samples          | PASSED | 160757=completed test/output/vcf/empty_output_filter_samples/.nxf.log
vcf/empty_output_filter                  | PASSED | 160758=completed test/output/vcf/empty_output_filter/.nxf.log
vcf/lb_b38                               | PASSED | 160759=completed test/output/vcf/lb_b38/.nxf.log
vcf/lb                                   | PASSED | 160760=completed test/output/vcf/lb/.nxf.log
vcf/lp_b38                               | PASSED | 160761=completed test/output/vcf/lp_b38/.nxf.log
vcf/lp                                   | PASSED | 160762=completed test/output/vcf/lp/.nxf.log
vcf/multiproject_classify                | PASSED | 160763=completed test/output/vcf/multiproject_classify/.nxf.log
vcf/snv_proband                          | PASSED | 160764=completed test/output/vcf/snv_proband/.nxf.log
vcf/snv_proband_trio_b38                 | PASSED | 160765=completed test/output/vcf/snv_proband_trio_b38/.nxf.log
vcf/snv_proband_trio_sample_filtering    | PASSED | 160766=completed test/output/vcf/snv_proband_trio_sample_filtering/.nxf.log
vcf/snv_proband_trio                     | PASSED | 160767=completed test/output/vcf/snv_proband_trio/.nxf.log
done
```