### PR TITLE
Fix: crams not reaching the report

### DIFF
--- a/modules/cram/validate.nf
+++ b/modules/cram/validate.nf
@@ -1,4 +1,4 @@
-process validate {
+process validateCram {
   label 'cram_validate'
 
   input:

--- a/subworkflows/call_snv_deepvariant.nf
+++ b/subworkflows/call_snv_deepvariant.nf
@@ -119,10 +119,10 @@ workflow deepvariant {
 
     // group gvcf chunks by project
     Channel.empty().mix(ch_gvcfs_per_chunk_per_sample_merged, ch_gvcfs_per_chunk_per_sample.single, ch_gvcfs_per_chunk_per_sample.zero)
-      | map { meta, gvcf -> [groupKey([*:meta].findAll { it.key != 'family' && it.key != 'sample' }, meta.project.samples.size()), [sample: meta.sample, gvcf: gvcf]] }
+      | map { meta, gvcf -> [groupKey([*:meta].findAll { it.key != 'family' && it.key != 'sample' }, meta.project.samples.size()), [meta: meta,sample: meta.sample, gvcf: gvcf]] }
       | groupTuple(remainder: true, sort: { left, right -> left.sample.index <=> right.sample.index })
       | map { key, group -> validateGroup(key, group) }
-      | map { meta, group -> [meta, group.collect{ it.gvcf }] }
+      | map { meta, group -> [[*:meta, project:[*:meta.project, samples: group.collect{ it.sample }]], group.collect{ it.gvcf }] }
       | set { ch_gvcfs_per_chunk_per_project }
 
     ch_gvcfs_per_chunk_per_project

--- a/subworkflows/call_str.nf
+++ b/subworkflows/call_str.nf
@@ -53,10 +53,10 @@ workflow str {
 
     // group by project
     Channel.empty().mix(ch_str_expansionhunter, ch_str_straglr, ch_str.zero_reads, ch_str_by_platform.ignore)
-      | map { meta, vcf -> [groupKey([*:meta].findAll { it.key != 'sample' }, meta.project.samples.size), [index: meta.sample.index, vcf: vcf]] }
-      | groupTuple(remainder: true, sort: { left, right -> left.index <=> right.index })
+      | map { meta, vcf -> [groupKey([*:meta].findAll { it.key != 'sample' }, meta.project.samples.size), [sample: meta.sample, vcf: vcf]] }
+      | groupTuple(remainder: true, sort: { left, right -> left.sample.index <=> right.sample.index })
       | map { key, group -> validateGroup(key, group) }
-      | map { meta, group -> [meta, group.collect { it.vcf }] }
+      | map { meta, group -> [[*:meta, project:[*:meta.project, samples: group.collect{it.sample}]], group.collect { it.vcf }] }
       | branch { meta, vcfs ->
           multiple: vcfs.count { it != null } > 1
                     return [meta, vcfs.findAll { it != null }]

--- a/subworkflows/call_sv.nf
+++ b/subworkflows/call_sv.nf
@@ -60,7 +60,7 @@ workflow sv {
     // group by project
     Channel.empty().mix(ch_sv_cutesv, ch_sv.zero_reads, ch_sv_by_platform.ignore)
       | map { meta, vcf -> [groupKey([*:meta].findAll { it.key != 'sample' }, meta.project.samples.size), [sample: meta.sample, vcf: vcf]] }
-      | groupTuple
+      | groupTuple(remainder: true, sort: { left, right -> left.sample.index <=> right.sample.index })
       | map { key, group -> validateGroup(key, group) }
       | map { meta, group -> [[*:meta, project:[*:meta.project, samples: group.collect{it.sample}]], group.sort { left, right -> left.sample.index <=> right.sample.index }.collect { it.vcf }] }
       | branch { meta, vcfs ->

--- a/vip_cram.nf
+++ b/vip_cram.nf
@@ -2,7 +2,7 @@ nextflow.enable.dsl=2
 
 include { parseCommonSampleSheet; getAssemblies } from './modules/sample_sheet'
 include { getCramRegex; validateGroup } from './modules/utils'
-include { validate } from './modules/cram/validate'
+include { validateCram } from './modules/cram/validate'
 include { vcf; validateVcfParams } from './vip_vcf'
 include { snv; validateCallSnvParams } from './subworkflows/call_snv'
 include { str; validateCallStrParams } from './subworkflows/call_str'
@@ -85,7 +85,7 @@ workflow {
   // validate sample crams
   ch_sample
     | map { meta -> [meta, meta.sample.cram] }
-    | validate
+    | validateCram
     | map { meta, cram, cramIndex, cramStats -> [*:meta, sample: [*:meta.sample, cram: [data: cram, index: cramIndex, stats: cramStats]]] }
     | set { ch_sample_validated }
 

--- a/vip_vcf.nf
+++ b/vip_vcf.nf
@@ -25,7 +25,7 @@ workflow vcf {
     take: meta
     main:
       meta
-                | branch { meta ->
+        | branch { meta ->
               run: !getProbandHpoIds(meta.project.samples).join(",").isEmpty() && areProbandHpoIdsIndentical(meta.project.samples)
               skip: true
         }

--- a/vip_vcf.nf
+++ b/vip_vcf.nf
@@ -237,8 +237,8 @@ workflow {
     | flatMap { project -> project.samples.collect { sample -> [project: project, sample: sample] } }
     | set { ch_sample }
 
-  // validate sample crams
-  ch_sample
+    // validate sample crams
+    ch_sample
     | branch{ meta ->
               validate: meta.sample.cram != null
               ready: true


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 

cram/complex                             | PASSED | 165618=completed output/cram/complex/.nxf.log
cram/multiproject                        | PASSED | 165619=completed output/cram/multiproject/.nxf.log
cram/nanopore_duo                        | PASSED | 165620=completed output/cram/nanopore_duo/.nxf.log
cram/nanopore                            | PASSED | 165621=completed output/cram/nanopore/.nxf.log
cram/single                              | PASSED | 165622=completed output/cram/single/.nxf.log
cram/trio                                | PASSED | 165623=completed output/cram/trio/.nxf.log
fastq/nanopore                           | PASSED | 165624=completed output/fastq/nanopore/.nxf.log
fastq/pacbio_hifi                        | PASSED | 165625=completed output/fastq/pacbio_hifi/.nxf.log
gvcf/multiproject                        | PASSED | 165626=completed output/gvcf/multiproject/.nxf.log
gvcf/trio                                | PASSED | 165627=completed output/gvcf/trio/.nxf.log
vcf/corner_cases                         | PASSED | 165628=completed output/vcf/corner_cases/.nxf.log
vcf/empty_input                          | PASSED | 165629=completed output/vcf/empty_input/.nxf.log
vcf/empty_output_filter_samples          | PASSED | 165630=completed output/vcf/empty_output_filter_samples/.nxf.log
vcf/empty_output_filter                  | PASSED | 165631=completed output/vcf/empty_output_filter/.nxf.log
vcf/filter_samples                       | PASSED | 165632=completed output/vcf/filter_samples/.nxf.log
vcf/multiproject_classify                | PASSED | 165633=completed output/vcf/multiproject_classify/.nxf.log
vcf/trio                                 | PASSED | 165634=completed output/vcf/trio/.nxf.log
vcf/vkgl_lb                              | PASSED | 165635=completed output/vcf/vkgl_lb/.nxf.log
vcf/vkgl_lp                              | PASSED | 165636=completed output/vcf/vkgl_lp/.nxf.log
