### PR TITLE
Fix bcftools sort --max-mem values

### DIFF
--- a/modules/cram/templates/concat_vcf.sh
+++ b/modules/cram/templates/concat_vcf.sh
@@ -19,7 +19,7 @@ concat () {
 }
 
 bcftools_sort () {
-  ${CMD_BCFTOOLS} norm --do-not-normalize --rm-dup all --no-version --threads "!{task.cpus}" "unsorted_!{vcfOut}" | ${CMD_BCFTOOLS} sort --temp-dir . --max-mem "!{task.memory.toGiga() - 1}" --output-type z --output "!{vcfOut}"
+  ${CMD_BCFTOOLS} norm --do-not-normalize --rm-dup all --no-version --threads "!{task.cpus}" "unsorted_!{vcfOut}" | ${CMD_BCFTOOLS} sort --temp-dir . --max-mem "!{task.memory.toGiga() - 1}G" --output-type z --output "!{vcfOut}"
 }
 
 index () {

--- a/modules/cram/templates/straglr_call.sh
+++ b/modules/cram/templates/straglr_call.sh
@@ -19,7 +19,7 @@ call_short_tandem_repeats () {
 
 index () {
   # workaround for https://github.com/molgenis/vip/issues/471
-  ${CMD_BCFTOOLS} reheader --fai "!{paramReferenceFai}" --temp-prefix . --threads "!{task.cpus}" "straglr.vcf" | ${CMD_BCFTOOLS} sort --temp-dir . --max-mem "!{task.memory.toGiga() - 1}" --output-type z --output "!{vcfOut}"
+  ${CMD_BCFTOOLS} reheader --fai "!{paramReferenceFai}" --temp-prefix . --threads "!{task.cpus}" "straglr.vcf" | ${CMD_BCFTOOLS} sort --temp-dir . --max-mem "!{task.memory.toGiga() - 1}G" --output-type z --output "!{vcfOut}"
 
   ${CMD_BCFTOOLS} index --csi --output "!{vcfOutIndex}" --threads "!{task.cpus}" "!{vcfOut}"
   ${CMD_BCFTOOLS} index --stats "!{vcfOut}" > "!{vcfOutStats}"


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 
