### PR TITLE
Reintroduce cuteSV workaround

### DIFF
--- a/modules/cram/templates/cutesv_call.sh
+++ b/modules/cram/templates/cutesv_call.sh
@@ -27,15 +27,42 @@ call_structural_variants () {
   ${CMD_CUTESV} "${args[@]}"
 }
 
+fixref () {
+  # Workaround for https://github.com/tjiangHIT/cuteSV/issues/124
+  while IFS=$'\t' read -r -a fields
+  do
+    if [[ "${fields[0]}" != \#* && "${fields[3]}" == "N" ]]; then
+      ref=$(${CMD_SAMTOOLS} faidx "!{reference}" "${fields[0]}:${fields[1]}-${fields[1]}" | sed -n '2 p')
+      fields[3]="${ref}"
+      length="${#fields[4]}"
+      #Fix breakend ALTS
+      if [[ "${fields[4]}" == \]* && "${fields[4]}" == *N ]]; then
+        fields[4]="${fields[4]:0:(length-1)}${ref}"
+      elif [[ "${fields[4]}" == *\[ && "${fields[4]}" == N* ]]; then
+        fields[4]="${ref}${fields[4]:1:length}"
+      #Fix regular insertion ALT
+      elif [[ "${fields[4]}" == N* && "${length}" -gt 1 ]]; then
+        fields[4]="${ref}${fields[4]:1:length}"
+      fi
+    fi
+    (IFS=$'\t'; echo "${fields[*]}") >> "fixed_ref_output.vcf"
+  done < "cutesv_output.vcf"
+}
+
 postprocess () {
-  ${CMD_BCFTOOLS} view --output-type z --output "!{vcfOut}" --no-version --threads "!{task.cpus}" "cutesv_output.vcf"
-  ${CMD_BCFTOOLS} index --csi --output "!{vcfOutIndex}" --threads "!{task.cpus}" "!{vcfOut}"
-  ${CMD_BCFTOOLS} index --stats "!{vcfOut}" > "!{vcfOutStats}"
+    # Workaround for https://github.com/tjiangHIT/cuteSV/issues/124
+    cat "fixed_ref_output.vcf" | awk -v FS='\t' -v OFS='\t' '/^[^#]/{gsub(/[YSB]/, "C", $4) gsub(/[WMRDHV]/, "A", $4) gsub("K", "G", $4)} 1' | ${CMD_BCFTOOLS} view --output-type z --output "replaced_IUPAC_cuteSV.vcf.gz" --no-version --threads "!{task.cpus}"
+    ${CMD_BCFTOOLS} index --csi --output "replaced_IUPAC_cuteSV.vcf.gz.csi" --threads "!{task.cpus}" "replaced_IUPAC_cuteSV.vcf.gz"
+    ${CMD_BCFTOOLS} view --output-type z --output "!{vcfOut}" --no-version --threads "!{task.cpus}" "cutesv_output.vcf"
+    ${CMD_BCFTOOLS} index --csi --output "!{vcfOutIndex}" --threads "!{task.cpus}" "!{vcfOut}"
+    ${CMD_BCFTOOLS} index --stats "!{vcfOut}" > "!{vcfOutStats}"
+    rm "replaced_IUPAC_cuteSV.vcf.gz.csi" "replaced_IUPAC_cuteSV.vcf.gz" "fixed_ref_output.vcf" "cutesv_output.vcf"
 }
 
 main() {
-  call_structural_variants
-  postprocess
+    call_structural_variants
+    fixref
+    postprocess
 }
 
 main "$@"


### PR DESCRIPTION
``` 
running tests ...
cram/nanopore_duo                        | PASSED | 172460=completed output/cram/nanopore_duo/.nxf.log
cram/nanopore                            | PASSED | 172461=completed output/cram/nanopore/.nxf.log
fastq/nanopore                           | PASSED | 172464=completed output/fastq/nanopore/.nxf.log
fastq/pacbio_hifi                        | PASSED | 172465=completed output/fastq/pacbio_hifi/.nxf.log
gvcf/liftover                            | PASSED | 172466=completed output/gvcf/liftover/.nxf.log
gvcf/multiproject                        | PASSED | 172467=completed output/gvcf/multiproject/.nxf.log
gvcf/trio                                | PASSED | 172468=completed output/gvcf/trio/.nxf.log
vcf/corner_cases                         | PASSED | 172469=completed output/vcf/corner_cases/.nxf.log
vcf/empty_input                          | PASSED | 172470=completed output/vcf/empty_input/.nxf.log
vcf/empty_output_filter_samples          | PASSED | 172471=completed output/vcf/empty_output_filter_samples/.nxf.log
vcf/empty_output_filter                  | PASSED | 172472=completed output/vcf/empty_output_filter/.nxf.log
vcf/filter_samples                       | PASSED | 172473=completed output/vcf/filter_samples/.nxf.log
vcf/liftover                             | PASSED | 172474=completed output/vcf/liftover/.nxf.log
vcf/multiproject_classify                | PASSED | 172475=completed output/vcf/multiproject_classify/.nxf.log
vcf/trio                                 | PASSED | 172476=completed output/vcf/trio/.nxf.log
vcf/vkgl_lb                              | PASSED | 172477=completed output/vcf/vkgl_lb/.nxf.log
vcf/vkgl_lp                              | PASSED | 172478=completed output/vcf/vkgl_lp/.nxf.log

cram/complex                             | PASSED | 172888=completed output/cram/complex/.nxf.log
cram/multiproject                        | PASSED | 172889=completed output/cram/multiproject/.nxf.log
cram/nanopore_duo                        | PASSED | 172890=completed output/cram/nanopore_duo/.nxf.log
cram/nanopore                            | PASSED | 172891=completed output/cram/nanopore/.nxf.log
cram/single                              | PASSED | 172892=completed output/cram/single/.nxf.log
cram/trio                                | PASSED | 172893=completed output/cram/trio/.nxf.log
```
