### PR TITLE
Workaround for Expansionhunter output missing SVTYPE

### DIFF
--- a/modules/cram/templates/expansionhunter_call.sh
+++ b/modules/cram/templates/expansionhunter_call.sh
@@ -21,8 +21,12 @@ postprocess () {
   # workaround: ExpansionHunter extracts the sample name from the .cram, this might not be equals to the actual sample identifier
   # workaround: ExpansionHunter produces an invalid .vcf due to missing contig headers, see https://github.com/Illumina/ExpansionHunter/issues/153
   # workaround: ExpansionHunter produces an invalid .vcf due to missing headers if all calls are ./., see <TODO report issue>
+  # workaround: ExpansionHunter are missing SVTYPE INFO field, see https://github.com/Illumina/ExpansionHunter/issues/186
   echo -e "!{sampleId}" > "samples.txt"
-  ${CMD_BCFTOOLS} reheader --fai "!{paramReferenceFai}" --samples samples.txt --threads "!{task.cpus}" "short_tandem_repeats.vcf" | ${CMD_BCFTOOLS} filter --exclude "GT=\"mis\"" --output-type z --output "!{vcfOut}" --no-version --threads "!{task.cpus}"
+  ${CMD_BCFTOOLS} reheader --fai "!{paramReferenceFai}" --samples samples.txt --threads "!{task.cpus}" "short_tandem_repeats.vcf" | \
+  ${CMD_BCFTOOLS} filter --exclude "GT=\"mis\"" --no-version --threads "!{task.cpus}"| \
+  awk 'BEGIN{FS=OFS="\t"} /^#/ {print; next} {$8="SVTYPE=STR;"$8; print; next;} { print; }' | \
+  ${CMD_BGZIP} -c > "!{vcfOut}"
 }
 
 index () {

--- a/test/suites/cram/resources/single.cfg
+++ b/test/suites/cram/resources/single.cfg
@@ -1,5 +1,4 @@
 params {
-    cram.call_str = false
     vcf.filter.classes = "LB,VUS,LP,P"
     vcf.filter_samples.classes = "U1,U2"
 }


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 
