### PR TITLE
Bump vcf-report 5.8.0 to 5.8.1

### DIFF
--- a/config/nxf.config
+++ b/config/nxf.config
@@ -1,5 +1,5 @@
 env {
-  VIP_VERSION = "7.2.0"
+  VIP_VERSION = "7.2.1"
 
   TMPDIR = "\${TMPDIR:-\${NXF_TEMP:-\$(mktemp -d)}}"
   APPTAINER_BIND = "${APPTAINER_BIND}"

--- a/config/nxf_vcf.config
+++ b/config/nxf_vcf.config
@@ -7,7 +7,7 @@ env {
   CMD_VEP = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vep-109.3.sif vep"
   CMD_FILTERVEP = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vep-109.3.sif filter_vep"
   CMD_STRANGER = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/stranger-0.8.1.sif stranger"
-  CMD_VCFREPORT="apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-report-5.8.0.sif"
+  CMD_VCFREPORT="apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-report-5.8.1.sif"
   CMD_VCFDECISIONTREE = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-decision-tree-3.9.0.sif"
   CMD_VCFINHERITANCEMATCHER = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-inheritance-matcher-3.0.1.sif"
 

--- a/install.sh
+++ b/install.sh
@@ -86,7 +86,7 @@ download_files() {
   urls+=("bcc157242cd9b09c66f015c52ef2d61d" "images/stranger-0.8.1.sif")
   urls+=("df4523b3b8a6ced93460ca05199c70f6" "images/vcf-decision-tree-3.9.0.sif")
   urls+=("cd0001d10876537458c86907a5a6dfdc" "images/vcf-inheritance-matcher-3.0.1.sif")
-  urls+=("cf410b802a31187a509e2b65ff098565" "images/vcf-report-5.8.1.sif")
+  urls+=("ce67e55ae73b2c57d43ddc1e8e4e374a" "images/vcf-report-5.8.1.sif")
   urls+=("f5ef389b4b5031edfbbe9eef4f545539" "images/vep-109.3.sif")
   urls+=("b1ece372a2c4db0c57a204d5a6175eb9" "nextflow-23.10.0-all")
   if [ "${assembly}" == "ALL" ] || [ "${assembly}" == "GRCh37" ]; then

--- a/install.sh
+++ b/install.sh
@@ -86,7 +86,7 @@ download_files() {
   urls+=("bcc157242cd9b09c66f015c52ef2d61d" "images/stranger-0.8.1.sif")
   urls+=("df4523b3b8a6ced93460ca05199c70f6" "images/vcf-decision-tree-3.9.0.sif")
   urls+=("cd0001d10876537458c86907a5a6dfdc" "images/vcf-inheritance-matcher-3.0.1.sif")
-  urls+=("cf410b802a31187a509e2b65ff098565" "images/vcf-report-5.8.0.sif")
+  urls+=("cf410b802a31187a509e2b65ff098565" "images/vcf-report-5.8.1.sif")
   urls+=("f5ef389b4b5031edfbbe9eef4f545539" "images/vep-109.3.sif")
   urls+=("b1ece372a2c4db0c57a204d5a6175eb9" "nextflow-23.10.0-all")
   if [ "${assembly}" == "ALL" ] || [ "${assembly}" == "GRCh37" ]; then

--- a/utils/apptainer/build.sh
+++ b/utils/apptainer/build.sh
@@ -96,7 +96,7 @@ main() {
   images+=("straglr-philres-1.4.2")
   images+=("vcf-decision-tree-3.9.0")
   images+=("vcf-inheritance-matcher-3.0.1")
-  images+=("vcf-report-5.8.0")
+  images+=("vcf-report-5.8.1")
 
   for i in "${!images[@]}"; do
     echo "---Building ${images[$i]}---"

--- a/utils/apptainer/def/vcf-report-5.8.1.def
+++ b/utils/apptainer/def/vcf-report-5.8.1.def
@@ -8,7 +8,7 @@ From: sif/build/openjdk-17.sif
 %post
     version_major=5
     version_minor=8
-    version_patch=0
+    version_patch=1
 
     # install
     apk update
@@ -16,7 +16,7 @@ From: sif/build/openjdk-17.sif
 
     mkdir -p /opt/vcf-report/lib
     curl -Ls -o /opt/vcf-report/lib/vcf-report.jar "https://github.com/molgenis/vip-report/releases/download/v${version_major}.${version_minor}.${version_patch}/vcf-report.jar"
-    echo "7d08912a3328df845a11a7e2f527fff0d18c70982839bdae1b62384961847cce  /opt/vcf-report/lib/vcf-report.jar" | sha256sum -c
+    echo "ad89dfa2573e5bb7b3ff74e4ef6823d56269d1df35c7c15f65cb2720a389a41c  /opt/vcf-report/lib/vcf-report.jar" | sha256sum -c
 
     # cleanup
     apk del .build-dependencies


### PR DESCRIPTION
```
$ bash test/test.sh -t vcf -c
running tests ...
vcf/corner_cases                         | PASSED | 181265=completed test/output/vcf/corner_cases/.nxf.log
vcf/empty_input                          | PASSED | 181266=completed test/output/vcf/empty_input/.nxf.log
vcf/empty_output_filter_samples          | PASSED | 181267=completed test/output/vcf/empty_output_filter_samples/.nxf.log
vcf/empty_output_filter                  | PASSED | 181268=completed test/output/vcf/empty_output_filter/.nxf.log
vcf/filter_samples                       | PASSED | 181269=completed test/output/vcf/filter_samples/.nxf.log
vcf/liftover                             | PASSED | 181270=completed test/output/vcf/liftover/.nxf.log
vcf/multiproject_classify                | PASSED | 181271=completed test/output/vcf/multiproject_classify/.nxf.log
vcf/trio                                 | PASSED | 181272=completed test/output/vcf/trio/.nxf.log
vcf/vkgl_lb                              | PASSED | 181273=completed test/output/vcf/vkgl_lb/.nxf.log
vcf/vkgl_lp                              | PASSED | 181274=completed test/output/vcf/vkgl_lp/.nxf.log
done
```