### PR TITLE
Fix DeepVariant trio calling out-of-memory errors & GIAB AshkenazimTrio_pacbio_ccs test

### DIFF
--- a/modules/cram/deepvariant.nf
+++ b/modules/cram/deepvariant.nf
@@ -108,7 +108,7 @@ process call_duo {
 process call_trio {
   label 'deepvariant_call_trio'
 
-  memory { 4.GB * task.cpus }
+  memory { 6.GB * task.cpus }
 
   input:
     tuple val(meta), path(cramChild), path(cramCraiChild),

--- a/test/suites/giab/AshkenazimTrio_pacbio_ccs.sh
+++ b/test/suites/giab/AshkenazimTrio_pacbio_ccs.sh
@@ -18,6 +18,7 @@ done
 args=()
 args+=("--workflow" "cram")
 args+=("--input" "${TEST_RESOURCES_DIR}/AshkenazimTrio_pacbio_ccs.tsv")
+args+=("--config" "${TEST_RESOURCES_DIR}/AshkenazimTrio_pacbio_ccs.cfg")
 args+=("--output" "${OUTPUT_DIR}")
 args+=("--resume")
 

--- a/test/suites/giab/resources/AshkenazimTrio_pacbio_ccs.cfg
+++ b/test/suites/giab/resources/AshkenazimTrio_pacbio_ccs.cfg
@@ -1,0 +1,9 @@
+process {
+  withLabel: 'deepvariant_call_trio' {
+    time = '3d'
+  }
+  withLabel:'vcf_annotate' {
+    time = '23h59m59s'
+    memory = '16GB'
+  }
+}


### PR DESCRIPTION
```
running tests ...
giab/AshkenazimTrio_pacbio_ccs           | PASSED | 36608=completed test/output/giab/AshkenazimTrio_pacbio_ccs/.nxf.log
done
```