### PR TITLE
Fix VEP plugin warnings

### DIFF
--- a/resources/vep/plugins/Inheritance.pm
+++ b/resources/vep/plugins/Inheritance.pm
@@ -98,14 +98,14 @@ sub run {
 
     # fail fast: sub-class doesn't contain transcript method
     return {} unless ($base_variation_feature_overlap_allele->can('transcript'));
+		my $transcript = $base_variation_feature_overlap_allele->transcript;
+
+		# fail fast: gene identifier is not from NCBI's Entrez Gene
+		return {} unless ($transcript->{_gene_symbol_source} eq 'EntrezGene');
 
 		# fail fast: missing gene identifier
 		my $gene_id = $transcript->{_gene_stable_id};
     return {} unless $gene_id;
-
-		# fail fast: gene identifier is not from NCBI's Entrez Gene
-    my $transcript = $base_variation_feature_overlap_allele->transcript;
-    return {} unless ($transcript->{_gene_symbol_source} eq 'EntrezGene');
 
     # fail fast: gene identifier unknown in gene_inheritance_modes.tsv
 		my $gene_value = $self->{gene_data}{$gene_id};

--- a/resources/vep/plugins/Inheritance.pm
+++ b/resources/vep/plugins/Inheritance.pm
@@ -119,7 +119,7 @@ sub run {
         $result->{InheritanceModesGene} = $gene_hash{mode};
         $result->{IncompletePenetrance} = '';
         if (defined $gene_hash{incompletePenetrance}) {
-            $result->{IncompletePenetrance} = $gene_hFix ash{incompletePenetrance};
+            $result->{IncompletePenetrance} = $gene_hash{incompletePenetrance};
         }
         if (defined $self->{include_pheno} && $pheno_data->{$gene_id}) {
             $result->{InheritanceModesPheno} = $pheno_data->{$gene_id};

--- a/resources/vep/plugins/VKGL.pm
+++ b/resources/vep/plugins/VKGL.pm
@@ -259,18 +259,24 @@ sub parse_file {
 }
 
 sub run {
-    my ($self, $tva) = @_;
+    my ($self, $base_variation_feature_overlap_allele) = @_;
 
-    my $transcript = $tva->transcript;
-    return {} unless ($transcript->{_gene_symbol_source} eq "EntrezGene");
+		# fail fast: sub-class doesn't contain transcript method
+    return {} unless ($base_variation_feature_overlap_allele->can('transcript'));
+		my $transcript = $base_variation_feature_overlap_allele->transcript;
 
-    my $vf = $tva->base_variation_feature;
-    my @vcf_line = @{$vf->{_line}};
+		# fail fast: gene identifier is not from NCBI's Entrez Gene
+		return {} unless ($transcript->{_gene_symbol_source} eq 'EntrezGene');
+
+		# fail fast: missing gene identifier
+		my $gene_id = $transcript->{_gene_stable_id};
+    return {} unless $gene_id;
+
+    my @vcf_line = @{$base_variation_feature_overlap_allele->base_variation_feature->{_line}};
     my $chr = $vcf_line[0];
     my $pos = $vcf_line[1];
     my $ref = $vcf_line[3];
-    my $alt = $vcf_line[4];
-    my $gene_id = $transcript->{_gene_stable_id};
+    my $alt = $vcf_line[4]; # assume site is biallelic
 
     my $result = {};
     if (!$self->{consensus_only}) {
@@ -303,6 +309,4 @@ sub run {
 
     return $result;
 }
-
-
 1;

--- a/resources/vep/plugins/ncER.pm
+++ b/resources/vep/plugins/ncER.pm
@@ -72,12 +72,15 @@ sub getScore {
 }
 
 sub run {
-  my ($self, $transcript_variation_allele) = @_;
+  my ($self, $base_variation_feature_overlap_allele) = @_;
 
-  my $vf = $transcript_variation_allele->variation_feature;
-  my $chr = $vf->{chr};
-  my $start = $vf->{start};
-  my $end = $vf->{end};
+  # fail fast: sub-class doesn't contain transcript method
+  return {} unless ($base_variation_feature_overlap_allele->can('variation_feature'));
+	my $variation_feature = $base_variation_feature_overlap_allele->variation_feature;
+
+  my $chr = $variation_feature->{chr};
+  my $start = $variation_feature->{start};
+  my $end = $variation_feature->{end};
   my $score;
   my $result = {};
 


### PR DESCRIPTION
```
running tests ...
vcf/corner_cases                         | PASSED | 183487=completed test/output/vcf/corner_cases/.nxf.log
vcf/empty_input                          | PASSED | 183488=completed test/output/vcf/empty_input/.nxf.log
vcf/empty_output_filter_samples          | PASSED | 183489=completed test/output/vcf/empty_output_filter_samples/.nxf.log
vcf/empty_output_filter                  | PASSED | 183490=completed test/output/vcf/empty_output_filter/.nxf.log
vcf/filter_samples                       | PASSED | 183491=completed test/output/vcf/filter_samples/.nxf.log
vcf/liftover                             | PASSED | 183492=completed test/output/vcf/liftover/.nxf.log
vcf/multiproject_classify                | PASSED | 183493=completed test/output/vcf/multiproject_classify/.nxf.log
vcf/trio                                 | PASSED | 183494=completed test/output/vcf/trio/.nxf.log
vcf/vkgl_lb                              | PASSED | 183495=completed test/output/vcf/vkgl_lb/.nxf.log
vcf/vkgl_lp                              | PASSED | 183496=completed test/output/vcf/vkgl_lp/.nxf.log
done
```