### PR TITLE
Workaround for HTSJDK removing additional ALT headers

### DIFF
--- a/modules/vcf/templates/classify.sh
+++ b/modules/vcf/templates/classify.sh
@@ -34,12 +34,14 @@ store_alt(){
 }
 
 insert_alt(){
-  #remove remaining ALT header (since htsjdk stores in a map, a single ALT remains)
-  zcat "!{vcfOut}" | sed '/^##ALT/d' > "!{vcfOut}".tmp
-  #re-insert the ALT headers
-  f1=$(<header.tmp)
-  awk -vf1="$f1" '/^#CHROM/{print f1;print;next}1' "!{vcfOut}".tmp | ${CMD_BGZIP} -c > "!{vcfOut}"
-  rm header.tmp
+  if [ -s header.tmp ]; then
+    #remove remaining ALT header (since htsjdk stores in a map, a single ALT remains)
+    zcat "!{vcfOut}" | sed '/^##ALT/d' > "!{vcfOut}".tmp
+    #re-insert the ALT headers
+    f1=$(<header.tmp)
+    awk -vf1="$f1" '/^#CHROM/{print f1;print;next}1' "!{vcfOut}".tmp | ${CMD_BGZIP} -c > "!{vcfOut}"
+    #rm header.tmp
+  fi
 }
 
 main () {

--- a/modules/vcf/templates/classify_samples.sh
+++ b/modules/vcf/templates/classify_samples.sh
@@ -37,12 +37,14 @@ store_alt(){
 }
 
 insert_alt(){
-  #remove remaining ALT header (since htsjdk stores in a map, a single ALT remains)
-  zcat "!{vcfOut}" | sed '/^##ALT/d' > "!{vcfOut}".tmp
-  #re-insert the ALT headers
-  f1=$(<header.tmp)
-  awk -vf1="$f1" '/^#CHROM/{print f1;print;next}1' "!{vcfOut}".tmp | ${CMD_BGZIP} -c > "!{vcfOut}"
-  rm header.tmp
+  if [ -s header.tmp ]; then
+    #remove remaining ALT header (since htsjdk stores in a map, a single ALT remains)
+    zcat "!{vcfOut}" | sed '/^##ALT/d' > "!{vcfOut}".tmp
+    #re-insert the ALT headers
+    f1=$(<header.tmp)
+    awk -vf1="$f1" '/^#CHROM/{print f1;print;next}1' "!{vcfOut}".tmp | ${CMD_BGZIP} -c > "!{vcfOut}"
+    #rm header.tmp
+  fi
 }
 
 main() {

--- a/modules/vcf/templates/inheritance.sh
+++ b/modules/vcf/templates/inheritance.sh
@@ -35,12 +35,14 @@ store_alt(){
 }
 
 insert_alt(){
-  #remove remaining ALT header (since htsjdk stores in a map, a single ALT remains)
-  zcat "!{vcfOut}" | sed '/^##ALT/d' > "!{vcfOut}".tmp
-  #re-insert the ALT headers
-  f1=$(<header.tmp)
-  awk -vf1="$f1" '/^#CHROM/{print f1;print;next}1' "!{vcfOut}".tmp | ${CMD_BGZIP} -c > "!{vcfOut}"
-  rm header.tmp
+  if [ -s header.tmp ]; then
+    #remove remaining ALT header (since htsjdk stores in a map, a single ALT remains)
+    zcat "!{vcfOut}" | sed '/^##ALT/d' > "!{vcfOut}".tmp
+    #re-insert the ALT headers
+    f1=$(<header.tmp)
+    awk -vf1="$f1" '/^#CHROM/{print f1;print;next}1' "!{vcfOut}".tmp | ${CMD_BGZIP} -c > "!{vcfOut}"
+    #rm header.tmp
+  fi
 }
 
 main() {


### PR DESCRIPTION
```
cram/complex                             | PASSED | 186183=completed output/cram/complex/.nxf.log
cram/multiproject                        | PASSED | 186184=completed output/cram/multiproject/.nxf.log
cram/nanopore_duo                        | PASSED | 186185=completed output/cram/nanopore_duo/.nxf.log
cram/nanopore                            | PASSED | 186186=completed output/cram/nanopore/.nxf.log
cram/single                              | PASSED | 186187=completed output/cram/single/.nxf.log
cram/trio                                | PASSED | 186188=completed output/cram/trio/.nxf.log

vcf/corner_cases                         | PASSED | 186441=completed output/vcf/corner_cases/.nxf.log
vcf/empty_input                          | PASSED | 186442=completed output/vcf/empty_input/.nxf.log
vcf/empty_output_filter_samples          | PASSED | 186443=completed output/vcf/empty_output_filter_samples/.nxf.log
vcf/empty_output_filter                  | PASSED | 186444=completed output/vcf/empty_output_filter/.nxf.log
vcf/filter_samples                       | PASSED | 186445=completed output/vcf/filter_samples/.nxf.log
vcf/liftover                             | PASSED | 186446=completed output/vcf/liftover/.nxf.log
vcf/multiproject_classify                | PASSED | 186447=completed output/vcf/multiproject_classify/.nxf.log
vcf/trio                                 | PASSED | 186448=completed output/vcf/trio/.nxf.log
vcf/vkgl_lb                              | PASSED | 186449=completed output/vcf/vkgl_lb/.nxf.log
vcf/vkgl_lp                              | PASSED | 186450=completed output/vcf/vkgl_lp/.nxf.log
```
