### PR TITLE
Add md5sum for all tests

### DIFF
--- a/test/suites/cram/complex.sh
+++ b/test/suites/cram/complex.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # shellcheck disable=SC1091
 source "${TEST_UTILS_DIR}/utils.sh"
 
-download_test_resource "illumina_WES_GRCh38_chr20.cram" "${TEST_RESOURCES_DIR}/downloads"
+download "$base_url/illumina_WES_GRCh38_chr20.cram" "5172c5531002d3a417da4744526caceb" "${TEST_RESOURCES_DIR}/downloads"
 ln -sf "${TEST_RESOURCES_DIR}/downloads/illumina_WES_GRCh38_chr20.cram" "${TEST_RESOURCES_DIR}/downloads/complex_solo_patient0.cram"
 ln -sf "${TEST_RESOURCES_DIR}/downloads/illumina_WES_GRCh38_chr20.cram" "${TEST_RESOURCES_DIR}/downloads/complex_duo_patient1.cram"
 ln -sf "${TEST_RESOURCES_DIR}/downloads/illumina_WES_GRCh38_chr20.cram" "${TEST_RESOURCES_DIR}/downloads/complex_duo_father1.cram"

--- a/test/suites/cram/multiproject.sh
+++ b/test/suites/cram/multiproject.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 # shellcheck disable=SC1091
 source "${TEST_UTILS_DIR}/utils.sh"
 
-download_test_resource "illumina_WES_GRCh38_chr20.bam" "${TEST_RESOURCES_DIR}/downloads"
-download_test_resource "illumina_WES_GRCh38_chr20.cram" "${TEST_RESOURCES_DIR}/downloads"
+download "$base_url/illumina_WES_GRCh38_chr20.bam" "a50b0cbac22d19197b868e4d81826e38" "${TEST_RESOURCES_DIR}/downloads"
+download "$base_url/illumina_WES_GRCh38_chr20.cram" "5172c5531002d3a417da4744526caceb" "${TEST_RESOURCES_DIR}/downloads"
 ln -sf "${TEST_RESOURCES_DIR}/downloads/illumina_WES_GRCh38_chr20.cram" "${TEST_RESOURCES_DIR}/downloads/multiproject_vip1.cram"
 ln -sf "${TEST_RESOURCES_DIR}/downloads/illumina_WES_GRCh38_chr20.bam" "${TEST_RESOURCES_DIR}/downloads/multiproject_vip2.bam"
 

--- a/test/suites/cram/nanopore.sh
+++ b/test/suites/cram/nanopore.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # shellcheck disable=SC1091
 source "${TEST_UTILS_DIR}/utils.sh"
 
-download_test_resource "nanopore.cram" "${TEST_RESOURCES_DIR}/downloads"
+download "$base_url/nanopore.cram" "e66e9d364766e0d45f03bdc25d42cf24" "${TEST_RESOURCES_DIR}/downloads"
   
 args=()
 args+=("--workflow" "cram")

--- a/test/suites/cram/nanopore_duo.sh
+++ b/test/suites/cram/nanopore_duo.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # shellcheck disable=SC1091
 source "${TEST_UTILS_DIR}/utils.sh"
 
-download_test_resource "nanopore.cram" "${TEST_RESOURCES_DIR}/downloads"
+download "$base_url/nanopore.cram" "e66e9d364766e0d45f03bdc25d42cf24" "${TEST_RESOURCES_DIR}/downloads"
 ln -sf "${TEST_RESOURCES_DIR}/downloads/nanopore.cram" "${TEST_RESOURCES_DIR}/downloads/nanopore_copy.cram"
 
 args=()

--- a/test/suites/cram/single.sh
+++ b/test/suites/cram/single.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # shellcheck disable=SC1091
 source "${TEST_UTILS_DIR}/utils.sh"
 
-download_test_resource "illumina_WES_GRCh38_chr20.cram" "${TEST_RESOURCES_DIR}/downloads"
+download "$base_url/illumina_WES_GRCh38_chr20.cram" "5172c5531002d3a417da4744526caceb" "${TEST_RESOURCES_DIR}/downloads"
 ln -sf "${TEST_RESOURCES_DIR}/downloads/illumina_WES_GRCh38_chr20.cram" "${TEST_RESOURCES_DIR}/downloads/single.cram"
 
 args=()

--- a/test/suites/cram/trio.sh
+++ b/test/suites/cram/trio.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 # shellcheck disable=SC1091
 source "${TEST_UTILS_DIR}/utils.sh"
 
-download_test_resource "illumina_WES_GRCh38_chr20.bam" "${TEST_RESOURCES_DIR}/downloads"
-download_test_resource "illumina_WES_GRCh38_chr20.cram" "${TEST_RESOURCES_DIR}/downloads"
+download "$base_url/illumina_WES_GRCh38_chr20.bam" "a50b0cbac22d19197b868e4d81826e38" "${TEST_RESOURCES_DIR}/downloads"
+download "$base_url/illumina_WES_GRCh38_chr20.cram" "5172c5531002d3a417da4744526caceb" "${TEST_RESOURCES_DIR}/downloads"
 ln -sf "${TEST_RESOURCES_DIR}/downloads/illumina_WES_GRCh38_chr20.bam" "${TEST_RESOURCES_DIR}/downloads/trio_patient.bam"
 ln -sf "${TEST_RESOURCES_DIR}/downloads/illumina_WES_GRCh38_chr20.cram" "${TEST_RESOURCES_DIR}/downloads/trio_father.cram"
 ln -sf "${TEST_RESOURCES_DIR}/downloads/illumina_WES_GRCh38_chr20.cram" "${TEST_RESOURCES_DIR}/downloads/trio_mother.cram"

--- a/test/suites/fastq/nanopore.sh
+++ b/test/suites/fastq/nanopore.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 # shellcheck disable=SC1091
 source "${TEST_UTILS_DIR}/utils.sh"
 
-download_test_resource "m54238_180628_014238_s0_10000.Q20.part_001.fastq.gz" "${TEST_RESOURCES_DIR}/downloads"
-download_test_resource "m54238_180628_014238_s0_10000.Q20.part_002.fastq.gz" "${TEST_RESOURCES_DIR}/downloads"
+download "$base_url/m54238_180628_014238_s0_10000.Q20.part_001.fastq.gz" "c1de90bc77fb413347e6a6aaf2e4660d" "${TEST_RESOURCES_DIR}/downloads"
+download "$base_url/m54238_180628_014238_s0_10000.Q20.part_002.fastq.gz" "db37d492beea41c505ce4ab5fe8df8ec" "${TEST_RESOURCES_DIR}/downloads"
 
 args=()
 args+=("--workflow" "fastq")

--- a/test/suites/fastq/pacbio_hifi.sh
+++ b/test/suites/fastq/pacbio_hifi.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # shellcheck disable=SC1091
 source "${TEST_UTILS_DIR}/utils.sh"
 
-download_test_resource "m54238_180628_014238_s0_10000.Q20.fastq.gz" "${TEST_RESOURCES_DIR}/downloads"
+download "$base_url/m54238_180628_014238_s0_10000.Q20.fastq.gz" "749786503c0ae5c9e325f025067ed4f2" "${TEST_RESOURCES_DIR}/downloads"
 
 args=()
 args+=("--workflow" "fastq")

--- a/test/utils.sh
+++ b/test/utils.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
+base_url=https://download.molgeniscloud.org/downloads/vip/test/resources/
+
 # arguments:
 #   $1  url
 #   $2  md5 checksum
@@ -26,26 +28,5 @@ download() {
   if ! echo "${md5}"  "${output_dir}/${filename}" | md5sum --check --quiet --status --strict; then
     echo -e "checksum check failed for '${output_dir}/${filename}'"
     exit 1
-  fi
-}
-
-# arguments:
-#   $1  filename on molgenis download server
-#   $2  output directory
-download_test_resource() {
-  local -r file="${1}"
-  local -r output_dir="${2}"
-  
-  local -r url="https://download.molgeniscloud.org/downloads/vip/test/resources/${file}"
-  local -r output="${output_dir}/${file}"
-
-  if [ ! -f "${output}" ]; then
-    mkdir -p "${output_dir}"
-    if ! wget --quiet --continue "${url}" --output-document "${output}"; then
-      echo -e "an error occurred downloading ${url}"
-        # wget always writes an (empty) output file regardless of errors
-        rm -f "${output}"
-        exit 1
-    fi
   fi
 }


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 

cram/complex                             | PASSED | 187552=completed output/cram/complex/.nxf.log
cram/multiproject                        | PASSED | 187553=completed output/cram/multiproject/.nxf.log
cram/nanopore_duo                        | PASSED | 187554=completed output/cram/nanopore_duo/.nxf.log
cram/nanopore                            | PASSED | 187555=completed output/cram/nanopore/.nxf.log
cram/single                              | PASSED | 187556=completed output/cram/single/.nxf.log
cram/trio                                | PASSED | 187557=completed output/cram/trio/.nxf.log

fastq/nanopore                           | PASSED | 187808=completed output/fastq/nanopore/.nxf.log
fastq/pacbio_hifi                        | PASSED | 187809=completed output/fastq/pacbio_hifi/.nxf.log


