### PR TITLE
Fix: ncER score can be undefined causing warnings in the VEP plugin

### DIFF
--- a/resources/vep/plugins/ncER.pm
+++ b/resources/vep/plugins/ncER.pm
@@ -65,7 +65,9 @@ sub getScore {
 
   my $size = @data;
   die("ERROR: Expecting no more than one score for a position.\n") unless $size <= 1;
-
+  if($size == 0){
+    return;
+  }
   #list of lines, tab separated values
   my @values = split("\t", $data[0]);
   return $values[3];
@@ -90,7 +92,13 @@ sub run {
   else{
     my $scoreStart = getScore($chr, $start);
     my $scoreEnd = getScore($chr, $start);
-    $score = $scoreStart > $scoreEnd ? $scoreStart : $scoreEnd;
+    if($scoreStart && $scoreEnd){
+        $score = $scoreStart > $scoreEnd ? $scoreStart : $scoreEnd;
+    }elsif($scoreStart){
+        $score = $scoreStart;
+    }else{
+        $score = $scoreEnd;
+    }
   }
 
   if($score) {

--- a/resources/vep/plugins/ncER.pm
+++ b/resources/vep/plugins/ncER.pm
@@ -92,16 +92,16 @@ sub run {
   else{
     my $scoreStart = getScore($chr, $start);
     my $scoreEnd = getScore($chr, $start);
-    if($scoreStart && $scoreEnd){
+    if(length $scoreStart && length $scoreEnd){
         $score = $scoreStart > $scoreEnd ? $scoreStart : $scoreEnd;
-    }elsif($scoreStart){
+    }elsif(length $scoreStart){
         $score = $scoreStart;
     }else{
         $score = $scoreEnd;
     }
   }
 
-  if($score) {
+  if(length $score) {
     $result->{ncER} = $score;
   }
   


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 

see BB: 
/groups/umcg-vipt/tmp05/projects/vip_validation/fix/ncer_warnings/test/output/vcf/vkgl_lp/.nxf.work/6a/2d65332fc6fd15bd21ac32f39f3fd8/
for the output log


vcf/aip                                  | PASSED | 191375=completed output/vcf/aip/.nxf.log
vcf/chd7                                 | PASSED | 191376=completed output/vcf/chd7/.nxf.log
vcf/corner_cases                         | PASSED | 191377=completed output/vcf/corner_cases/.nxf.log
vcf/deb_register                         | PASSED | 191378=completed output/vcf/deb_register/.nxf.log
vcf/empty_input                          | PASSED | 191379=completed output/vcf/empty_input/.nxf.log
vcf/empty_output_filter_samples          | PASSED | 191380=completed output/vcf/empty_output_filter_samples/.nxf.log
vcf/empty_output_filter                  | PASSED | 191381=completed output/vcf/empty_output_filter/.nxf.log
vcf/filter_samples                       | PASSED | 191382=completed output/vcf/filter_samples/.nxf.log
vcf/liftover                             | PASSED | 191383=completed output/vcf/liftover/.nxf.log
vcf/multiproject_classify                | PASSED | 191384=completed output/vcf/multiproject_classify/.nxf.log
vcf/mvid                                 | PASSED | 191385=completed output/vcf/mvid/.nxf.log
vcf/trio                                 | PASSED | 191386=completed output/vcf/trio/.nxf.log
vcf/vkgl_lb                              | PASSED | 191387=completed output/vcf/vkgl_lb/.nxf.log
vcf/vkgl_lp                              | PASSED | 191388=completed output/vcf/vkgl_lp/.nxf.log
