### PR TITLE
Chore/report601

### DIFF
--- a/config/nxf_vcf.config
+++ b/config/nxf_vcf.config
@@ -7,7 +7,7 @@ env {
   CMD_VEP = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vep-111.0.sif vep"
   CMD_FILTERVEP = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vep-111.0.sif filter_vep"
   CMD_STRANGER = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/stranger-0.8.1.sif stranger"
-  CMD_VCFREPORT="apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-report-6.0.0.sif"
+  CMD_VCFREPORT="apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-report-6.0.1.sif"
   CMD_VCFDECISIONTREE = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-decision-tree-4.0.0.sif"
   CMD_VCFINHERITANCEMATCHER = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-inheritance-matcher-3.0.2.sif"
 

--- a/install.sh
+++ b/install.sh
@@ -86,7 +86,7 @@ download_files() {
   urls+=("bcc157242cd9b09c66f015c52ef2d61d" "images/stranger-0.8.1.sif")
   urls+=("4fbbd8642ead7754cb8cc19740e18175" "images/vcf-decision-tree-4.0.0.sif")
   urls+=("e58983a7dd9cdfb4ca71bc8a0a40a4a3" "images/vcf-inheritance-matcher-3.0.2.sif")
-  urls+=("e7f9001dc3d866a6ad6a506261008458" "images/vcf-report-6.0.0.sif")
+  urls+=("FIXME" "images/vcf-report-6.0.1.sif")
   urls+=("7bffc236a7c65b2b2e2e5f7d64beaa87" "images/vep-111.0.sif")
   urls+=("b1ece372a2c4db0c57a204d5a6175eb9" "nextflow-23.10.0-all")
   if [ "${assembly}" == "ALL" ] || [ "${assembly}" == "GRCh37" ]; then

--- a/install.sh
+++ b/install.sh
@@ -86,7 +86,7 @@ download_files() {
   urls+=("bcc157242cd9b09c66f015c52ef2d61d" "images/stranger-0.8.1.sif")
   urls+=("4fbbd8642ead7754cb8cc19740e18175" "images/vcf-decision-tree-4.0.0.sif")
   urls+=("e58983a7dd9cdfb4ca71bc8a0a40a4a3" "images/vcf-inheritance-matcher-3.0.2.sif")
-  urls+=("FIXME" "images/vcf-report-6.0.1.sif")
+  urls+=("3a07c5cb8a5cd5ad3a05625685cbbf6c" "images/vcf-report-6.0.1.sif")
   urls+=("7bffc236a7c65b2b2e2e5f7d64beaa87" "images/vep-111.0.sif")
   urls+=("b1ece372a2c4db0c57a204d5a6175eb9" "nextflow-23.10.0-all")
   if [ "${assembly}" == "ALL" ] || [ "${assembly}" == "GRCh37" ]; then

--- a/utils/apptainer/build.sh
+++ b/utils/apptainer/build.sh
@@ -96,7 +96,7 @@ main() {
   images+=("straglr-philres-1.4.2")
   images+=("vcf-decision-tree-4.0.0")
   images+=("vcf-inheritance-matcher-3.0.2")
-  images+=("vcf-report-6.0.0")
+  images+=("vcf-report-6.0.1")
 
   for i in "${!images[@]}"; do
     echo "---Building ${images[$i]}---"

--- a/utils/apptainer/def/vcf-report-6.0.1.def
+++ b/utils/apptainer/def/vcf-report-6.0.1.def
@@ -8,7 +8,7 @@ From: sif/build/openjdk-17.sif
 %post
     version_major=6
     version_minor=0
-    version_patch=0
+    version_patch=1
 
     # install
     apk update
@@ -16,7 +16,7 @@ From: sif/build/openjdk-17.sif
 
     mkdir -p /opt/vcf-report/lib
     curl -Ls -o /opt/vcf-report/lib/vcf-report.jar "https://github.com/molgenis/vip-report/releases/download/v${version_major}.${version_minor}.${version_patch}/vcf-report.jar"
-    echo "8505e0a11b95ee4be1eabd99795370deb07bff7fd1beca1fd30077b65f520adb  /opt/vcf-report/lib/vcf-report.jar" | sha256sum -c
+    echo "0630bf628d3c9a21c0cada773b8cfcdd5a9a4f94ab494ca53a1b4b63ae458418  /opt/vcf-report/lib/vcf-report.jar" | sha256sum -c
 
     # cleanup
     apk del .build-dependencies


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 
vcf/aip                                  | PASSED | 195671=completed output/vcf/aip/.nxf.log
vcf/chd7                                 | PASSED | 195672=completed output/vcf/chd7/.nxf.log
vcf/corner_cases                         | PASSED | 195673=completed output/vcf/corner_cases/.nxf.log
vcf/deb_register                         | PASSED | 195674=completed output/vcf/deb_register/.nxf.log
vcf/empty_input                          | PASSED | 195675=completed output/vcf/empty_input/.nxf.log
vcf/empty_output_filter_samples          | PASSED | 195676=completed output/vcf/empty_output_filter_samples/.nxf.log
vcf/empty_output_filter                  | PASSED | 195677=completed output/vcf/empty_output_filter/.nxf.log
vcf/filter_samples                       | PASSED | 195678=completed output/vcf/filter_samples/.nxf.log
vcf/liftover                             | PASSED | 195679=completed output/vcf/liftover/.nxf.log
vcf/multiproject_classify                | PASSED | 195680=completed output/vcf/multiproject_classify/.nxf.log
vcf/mvid                                 | PASSED | 195681=completed output/vcf/mvid/.nxf.log
vcf/trio                                 | PASSED | 195682=completed output/vcf/trio/.nxf.log
vcf/vkgl_lb                              | PASSED | 195683=completed output/vcf/vkgl_lb/.nxf.log
vcf/vkgl_lp                              | PASSED | 195684=completed output/vcf/vkgl_lp/.nxf.log

