### PR TITLE
Fix install script for cases that nextflow already exists

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -186,7 +186,8 @@ create_symlinks() {
   local -r output_dir="${1}"
 
   local -r file="nextflow-23.10.0-all"
-  (cd "${output_dir}" && chmod +x "${file}" && rm -f nextflow && ln -s ${file} "nextflow")
+  (cd "${output_dir}" && chmod +x "${file}") || echo "Failed to set permissions for ${file}"
+  (cd "${output_dir}" && rm -f nextflow && ln -s ${file} "nextflow")
 
   chmod +x "${output_dir}/vip.sh"
   if [ ! -f "${output_dir}/vip" ]; then


### PR DESCRIPTION
Fixes the absence of "nextflow" symlink if changing permissions failed due to the nextflow version already being installed by a different user.

![image](https://github.com/molgenis/vip/assets/3714029/fdc93866-3215-4e13-8030-4eea5bfc009e)

![image](https://github.com/molgenis/vip/assets/3714029/e38ab743-37ef-40d1-b320-127d1b01074f)


End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 
