### PR TITLE
Fix: Only run CAPICE if there are variants to do predictions on

### DIFF
--- a/modules/vcf/templates/annotate.sh
+++ b/modules/vcf/templates/annotate.sh
@@ -37,7 +37,10 @@ annot_sv() {
 capice() {
   capice_vep
   capice_bcftools
-  capice_predict
+  #only run capice if there a variants with annotations, e.g. <STR> only VCF files do not yield any annotated lines
+  if [ "$(zcat "${capiceInputPath}" | grep -vc "^#")" -gt 0 ]; then
+    capice_predict
+  fi
 }
 
 capice_vep() {

--- a/test/suites/vcf/resources/str.cfg
+++ b/test/suites/vcf/resources/str.cfg
@@ -1,0 +1,4 @@
+params {
+    vcf.filter.classes = "LQ,B,LB,VUS,LP,P"
+    vcf.filter_samples.classes = "U1,U2,U3"
+}

--- a/test/suites/vcf/resources/str.tsv
+++ b/test/suites/vcf/resources/str.tsv
@@ -1,0 +1,4 @@
+family_id	individual_id	paternal_id	maternal_id	sex	affected	proband	hpo_ids	vcf
+FAM0	PROBAND0	FATHER0	MOTHER0	male	true	true	HP:0001250,HP:0001166	str.vcf
+FAM0	FATHER0			male	false			str.vcf
+FAM0	MOTHER0			female	false			str.vcf

--- a/test/suites/vcf/resources/str.vcf
+++ b/test/suites/vcf/resources/str.vcf
@@ -1,0 +1,22 @@
+##fileformat=VCFv4.2
+##FILTER=<ID=PASS,Description="All filters passed">
+##FORMAT=<ID=AD,Number=R,Type=Integer,Description="Allelic depths for the ref and alt alleles in the order listed">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth (reads with MQ=255 or with bad mates are filtered)">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##INFO=<ID=END,Number=1,Type=Integer,Description="End position of the variant">
+##INFO=<ID=REF,Number=1,Type=Integer,Description="Reference copy number">
+##INFO=<ID=REPID,Number=1,Type=String,Description="Repeat identifier as specified in the variant catalog">
+##INFO=<ID=VARID,Number=1,Type=String,Description="Variant identifier as specified in the variant catalog">
+##INFO=<ID=RL,Number=1,Type=Integer,Description="Reference length in bp">
+##INFO=<ID=RU,Number=1,Type=String,Description="Repeat unit in the reference orientation">
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
+##contig=<ID=chr22,length=50818468>
+##ALT=<ID=STR13,Description="Allele comprised of 13 repeat units">
+##ALT=<ID=STR23,Description="Allele comprised of 23 repeat units">
+##ALT=<ID=STR103,Description="Allele comprised of 103 repeat units">
+##ALT=<ID=STR3,Description="Allele comprised of 3 repeat units">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	PROBAND0	MOTHER0	FATHER0
+chr22	17199629	.	A	<STR13>	15	PASS	SVTYPE=STR;END=149390841;REF=6;RL=13;RU=CGGCGG;REPID=BLA1;VARID=BLA1	GT:AD:DP	1/1:0,50:50	0/0:50,0:50	0/0:50,0:50
+chr22	19134440	.	G	<STR23>	11	PASS	SVTYPE=STR;END=149390841;REF=6;RL=23;RU=CGGCGG;REPID=BLA2;VARID=BLA2	GT:AD:DP	1/1:0,50:50	0/0:50,0:50	0/0:50,0:50
+chr22	19253958	.	C	<STR103>	11	PASS	SVTYPE=STR;END=149390841;REF=6;RL=103;RU=CGGCGG;REPID=BLA3;VARID=BLA3_I	GT:AD:DP	1/1:0,50:50	0/0:50,0:50	0/0:50,0:50
+chr22	19718955	.	C	<STR3>	10	PASS	SVTYPE=STR;END=149390841;REF=6;RL=3;RU=CGGCGG;REPID=BLA4;VARID=BLA4	GT:AD:DP	1/1:0,50:50	0/0:50,0:50	0/0:50,0:50

--- a/test/suites/vcf/str.sh
+++ b/test/suites/vcf/str.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+args=()
+args+=("--workflow" "vcf")
+args+=("--input" "${TEST_RESOURCES_DIR}/str.tsv")
+args+=("--config" "${TEST_RESOURCES_DIR}/str.cfg")
+args+=("--output" "${OUTPUT_DIR}")
+args+=("--resume")
+
+vip "${args[@]}" 1> /dev/null
+
+# compare expected to actual output and store result
+if [ "$(zcat "${OUTPUT_DIR}/vip.vcf.gz" | grep -vc "^#")" -eq 4 ]; then
+  result="0"
+else
+  result="1"
+fi
+echo -n "${result}" > "${OUTPUT_DIR}/.exitcode"
+
+# always exit with success error code
+exit 0


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 
