### PR TITLE
Update minimap 2.26 -> 2.27 + update preset

### DIFF
--- a/config/nxf_fastq.config
+++ b/config/nxf_fastq.config
@@ -22,6 +22,7 @@ process {
 params {
   minimap2 {
     soft_clipping = true;
+    nanopore_preset = "lr:hq";
   }
 
   fastp {

--- a/config/nxf_fastq.config
+++ b/config/nxf_fastq.config
@@ -1,7 +1,7 @@
 includeConfig 'nxf_cram.config'
 
 env {
-  CMD_MINIMAP2 = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/minimap2-2.26.sif minimap2"
+  CMD_MINIMAP2 = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/minimap2-2.27.sif minimap2"
   CMD_FASTP = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/fastp-0.23.4.sif /opt/fastp"
 }
 

--- a/docs/usage/config.md
+++ b/docs/usage/config.md
@@ -27,6 +27,7 @@ Please take note of the fact that for a different reference fasta.gz the  unzipp
 |---------------------------|-------------|--------------------------------------------------------------------------------------------------------|
 | GRCh38.reference.fastaMmi | *installed* | for details, see [here](https://github.com/lh3/minimap2)                                               |
 | minimap2.soft_clipping    | true        | In SAM output, use soft clipping for supplementary alignments (required when STR calling with Straglr) |
+| minimap2.nanopore_preset  | lr:hq       | Preset to use for aligning Nanopore data, options: 'lr:hq', 'map-ont'.                                 |
 
 ### CRAM
 | key                                         | default        | description                                                                                                                                                     |

--- a/install.sh
+++ b/install.sh
@@ -79,7 +79,7 @@ download_files() {
   urls+=("494c8c9e1031828f48027e34032de423" "images/gado-1.0.3.sif")
   urls+=("d25ba2124ef883b1b6f7a2eff2cb8201" "images/glnexus_v1.4.5-patched.sif")
   urls+=("ff8aceb2c9f185307a69b981ba08efd8" "images/manta-1.6.0.sif")
-  urls+=("1e0caddbdd755bf608ef024e3d0a2f19" "images/minimap2-2.26.sif")
+  urls+=("FIXME" "images/minimap2-2.27.sif")
   urls+=("06ac8a76a307fa42fffd80ab906fd24b" "images/picard-3.1.1.sif")
   urls+=("9a4b685b26744113d3ea0a3904c02706" "images/samtools-1.17-patch1.sif")
   urls+=("2c18fcda2660792a7c8ba390463ae7ac" "images/straglr-philres-1.4.2.sif")

--- a/install.sh
+++ b/install.sh
@@ -79,7 +79,7 @@ download_files() {
   urls+=("494c8c9e1031828f48027e34032de423" "images/gado-1.0.3.sif")
   urls+=("d25ba2124ef883b1b6f7a2eff2cb8201" "images/glnexus_v1.4.5-patched.sif")
   urls+=("ff8aceb2c9f185307a69b981ba08efd8" "images/manta-1.6.0.sif")
-  urls+=("FIXME" "images/minimap2-2.27.sif")
+  urls+=("7486bd5de526d9888df8eea2d8bdea48" "images/minimap2-2.27.sif")
   urls+=("06ac8a76a307fa42fffd80ab906fd24b" "images/picard-3.1.1.sif")
   urls+=("9a4b685b26744113d3ea0a3904c02706" "images/samtools-1.17-patch1.sif")
   urls+=("2c18fcda2660792a7c8ba390463ae7ac" "images/straglr-philres-1.4.2.sif")

--- a/modules/fastq/minimap2.nf
+++ b/modules/fastq/minimap2.nf
@@ -19,7 +19,7 @@ process minimap2_align {
     
     sampleId=meta.sample.individual_id;
     platform=meta.project.sequencing_platform
-    preset=platform == "nanopore" ? "map-ont" : (platform == "pacbio_hifi" ? "map-hifi" : "")
+    preset=platform == "nanopore" ? params.minimap2.nanopore_preset : (platform == "pacbio_hifi" ? "map-hifi" : "")
     softClipping=params.minimap2.soft_clipping 
 
     //fastp params

--- a/utils/apptainer/build.sh
+++ b/utils/apptainer/build.sh
@@ -89,7 +89,7 @@ main() {
   #images+=("glnexus_v1.4.5-patched")
   images+=("gado-1.0.3")
   images+=("manta-1.6.0")
-  images+=("minimap2-2.26")
+  images+=("minimap2-2.27")
   images+=("picard-3.1.1")
   images+=("samtools-1.17-patch1")
   images+=("stranger-0.8.1")

--- a/utils/apptainer/def/minimap2-2.27.def
+++ b/utils/apptainer/def/minimap2-2.27.def
@@ -10,7 +10,7 @@ Stage: build
 
     # download
     curl -Ls -o minimap2-${version_major}.${version_minor}.tar.bz2 https://github.com/lh3/minimap2/releases/download/v${version_major}.${version_minor}/minimap2-${version_major}.${version_minor}.tar.bz2
-    echo "6a588efbd273bff4f4808d5190957c50272833d2daeb4407ccf4c1b78143624c  minimap2-${version_major}.${version_minor}.tar.bz2" | sha256sum -c
+    echo "9f7d3ca20b8f795222440c00eef5131c0740065f87aa7f4a1e0bfb2d8e820753  minimap2-${version_major}.${version_minor}.tar.bz2" | sha256sum -c
 
     # install
     tar xf minimap2-${version_major}.${version_minor}.tar.bz2

--- a/utils/apptainer/def/minimap2-2.27.def
+++ b/utils/apptainer/def/minimap2-2.27.def
@@ -4,7 +4,7 @@ Stage: build
 
 %post
     version_major=2
-    version_minor=26
+    version_minor=27
 
     apk --no-cache add -X http://dl-cdn.alpinelinux.org/alpine/edge/community curl build-base zlib-dev bzip2-dev libdeflate-dev
 


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 

fastq/nanopore                           | PASSED | 204484=completed output/fastq/nanopore/.nxf.log
fastq/pacbio_hifi                        | PASSED | 204485=completed output/fastq/pacbio_hifi/.nxf.log

Runs with both presets result in no differences for tested sample:
vaxtron /groups/umcg-gdio/tmp03/umcg-bcharbon/nanopore/minimap/
