### PR TITLE
VIP 7.6.0 - update inheritance

### DIFF
--- a/config/nxf_vcf.config
+++ b/config/nxf_vcf.config
@@ -9,7 +9,7 @@ env {
   CMD_STRANGER = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/stranger-0.8.1.sif stranger"
   CMD_VCFREPORT="apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-report-6.0.1.sif"
   CMD_VCFDECISIONTREE = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-decision-tree-4.0.0.sif"
-  CMD_VCFINHERITANCEMATCHER = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-inheritance-matcher-3.0.2.sif"
+  CMD_VCFINHERITANCEMATCHER = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-inheritance-matcher-3.1.0.sif"
 
   // workaround for SAMtools https://github.com/samtools/samtools/issues/1366#issuecomment-769170935
   REF_PATH = ":"

--- a/install.sh
+++ b/install.sh
@@ -85,7 +85,7 @@ download_files() {
   urls+=("2c18fcda2660792a7c8ba390463ae7ac" "images/straglr-philres-1.4.2.sif")
   urls+=("bcc157242cd9b09c66f015c52ef2d61d" "images/stranger-0.8.1.sif")
   urls+=("4fbbd8642ead7754cb8cc19740e18175" "images/vcf-decision-tree-4.0.0.sif")
-  urls+=("TODO" "images/vcf-inheritance-matcher-3.1.0.sif")
+  urls+=("9c4d7b48138f29651cdd45eb8d0cc4b6" "images/vcf-inheritance-matcher-3.1.0.sif")
   urls+=("3a07c5cb8a5cd5ad3a05625685cbbf6c" "images/vcf-report-6.0.1.sif")
   urls+=("7bffc236a7c65b2b2e2e5f7d64beaa87" "images/vep-111.0.sif")
   urls+=("b1ece372a2c4db0c57a204d5a6175eb9" "nextflow-23.10.0-all")

--- a/install.sh
+++ b/install.sh
@@ -85,7 +85,7 @@ download_files() {
   urls+=("2c18fcda2660792a7c8ba390463ae7ac" "images/straglr-philres-1.4.2.sif")
   urls+=("bcc157242cd9b09c66f015c52ef2d61d" "images/stranger-0.8.1.sif")
   urls+=("4fbbd8642ead7754cb8cc19740e18175" "images/vcf-decision-tree-4.0.0.sif")
-  urls+=("e58983a7dd9cdfb4ca71bc8a0a40a4a3" "images/vcf-inheritance-matcher-3.0.2.sif")
+  urls+=("TODO" "images/vcf-inheritance-matcher-3.1.0.sif")
   urls+=("3a07c5cb8a5cd5ad3a05625685cbbf6c" "images/vcf-report-6.0.1.sif")
   urls+=("7bffc236a7c65b2b2e2e5f7d64beaa87" "images/vep-111.0.sif")
   urls+=("b1ece372a2c4db0c57a204d5a6175eb9" "nextflow-23.10.0-all")

--- a/utils/apptainer/build.sh
+++ b/utils/apptainer/build.sh
@@ -95,7 +95,7 @@ main() {
   images+=("stranger-0.8.1")
   images+=("straglr-philres-1.4.2")
   images+=("vcf-decision-tree-4.0.0")
-  images+=("vcf-inheritance-matcher-3.0.2")
+  images+=("vcf-inheritance-matcher-3.1.0")
   images+=("vcf-report-6.0.1")
 
   for i in "${!images[@]}"; do

--- a/utils/apptainer/def/vcf-inheritance-matcher-3.1.0.def
+++ b/utils/apptainer/def/vcf-inheritance-matcher-3.1.0.def
@@ -7,8 +7,8 @@ From: sif/build/openjdk-17.sif
 
 %post
     version_major=3
-    version_minor=0
-    version_patch=2
+    version_minor=1
+    version_patch=0
 
     # install
     apk update
@@ -16,7 +16,7 @@ From: sif/build/openjdk-17.sif
 
     mkdir -p /opt/vcf-inheritance-matcher/lib
     curl -Ls -o /opt/vcf-inheritance-matcher/lib/vcf-inheritance-matcher.jar "https://github.com/molgenis/vip-inheritance-matcher/releases/download/v${version_major}.${version_minor}.${version_patch}/vcf-inheritance-matcher.jar"
-    echo "76b400b79b720099ae12a2cbe49a147123ab6543338f3d7b3e7539b087c250c3  /opt/vcf-inheritance-matcher/lib/vcf-inheritance-matcher.jar" | sha256sum -c
+    echo "1b4b9f33542ce0e19c7bc22542e857137ca12f2e62f68f4d7f0254da43f2143b  /opt/vcf-inheritance-matcher/lib/vcf-inheritance-matcher.jar" | sha256sum -c
 
     # cleanup
     apk del .build-dependencies

--- a/vip.sh
+++ b/vip.sh
@@ -7,7 +7,7 @@ SCRIPT_NAME="$(basename "$0")"
 # SCRIPT_DIR is incorrect when vip.sh is submitted as a Slurm job that is submitted as part of another Slurm job
 VIP_DIR="${VIP_DIR:-"${SCRIPT_DIR}"}"
 
-VIP_VERSION="7.5.0"
+VIP_VERSION="7.6.0"
 
 display_version() {
   echo -e "${VIP_VERSION}"


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 
- [ ] 
vcf/aip                                  | PASSED | 210296=completed output/vcf/aip/.nxf.log
vcf/chd7                                 | PASSED | 210297=completed output/vcf/chd7/.nxf.log
vcf/corner_cases                         | PASSED | 210298=completed output/vcf/corner_cases/.nxf.log
vcf/deb_register                         | PASSED | 210612=completed output/vcf/deb_register/.nxf.log
vcf/empty_input                          | PASSED | 210300=completed output/vcf/empty_input/.nxf.log
vcf/empty_output_filter_samples          | PASSED | 210301=completed output/vcf/empty_output_filter_samples/.nxf.log
vcf/empty_output_filter                  | PASSED | 210302=completed output/vcf/empty_output_filter/.nxf.log
vcf/filter_samples                       | PASSED | 210303=completed output/vcf/filter_samples/.nxf.log
vcf/liftover                             | PASSED | 210304=completed output/vcf/liftover/.nxf.log
vcf/multiproject_classify                | PASSED | 210305=completed output/vcf/multiproject_classify/.nxf.log
vcf/mvid                                 | PASSED | 210306=completed output/vcf/mvid/.nxf.log
vcf/str                                  | PASSED | 210307=completed output/vcf/str/.nxf.log
vcf/trio                                 | PASSED | 210308=completed output/vcf/trio/.nxf.log
vcf/vkgl_lb                              | PASSED | 210309=completed output/vcf/vkgl_lb/.nxf.log
vcf/vkgl_lp                              | PASSED | 210310=completed output/vcf/vkgl_lp/.nxf.log
done


