### PR TITLE
Feat/bump report 6.0.2

### DIFF
--- a/config/nxf_vcf.config
+++ b/config/nxf_vcf.config
@@ -7,7 +7,7 @@ env {
   CMD_VEP = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vep-111.0.sif vep"
   CMD_FILTERVEP = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vep-111.0.sif filter_vep"
   CMD_STRANGER = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/stranger-0.8.1.sif stranger"
-  CMD_VCFREPORT="apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-report-6.0.1.sif"
+  CMD_VCFREPORT="apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-report-6.0.2.sif"
   CMD_VCFDECISIONTREE = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-decision-tree-4.0.0.sif"
   CMD_VCFINHERITANCEMATCHER = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-inheritance-matcher-3.1.0.sif"
 

--- a/install.sh
+++ b/install.sh
@@ -86,7 +86,7 @@ download_files() {
   urls+=("bcc157242cd9b09c66f015c52ef2d61d" "images/stranger-0.8.1.sif")
   urls+=("4fbbd8642ead7754cb8cc19740e18175" "images/vcf-decision-tree-4.0.0.sif")
   urls+=("9c4d7b48138f29651cdd45eb8d0cc4b6" "images/vcf-inheritance-matcher-3.1.0.sif")
-  urls+=("3a07c5cb8a5cd5ad3a05625685cbbf6c" "images/vcf-report-6.0.1.sif")
+  urls+=("7f3c5115f68998067a404c922b2e3b15" "images/vcf-report-6.0.2.sif")
   urls+=("7bffc236a7c65b2b2e2e5f7d64beaa87" "images/vep-111.0.sif")
   urls+=("b1ece372a2c4db0c57a204d5a6175eb9" "nextflow-23.10.0-all")
   if [ "${assembly}" == "ALL" ] || [ "${assembly}" == "GRCh37" ]; then

--- a/utils/apptainer/build.sh
+++ b/utils/apptainer/build.sh
@@ -96,7 +96,7 @@ main() {
   images+=("straglr-1.4.4_vip_v2")
   images+=("vcf-decision-tree-4.0.0")
   images+=("vcf-inheritance-matcher-3.1.0")
-  images+=("vcf-report-6.0.1")
+  images+=("vcf-report-6.0.2")
 
   for i in "${!images[@]}"; do
     echo "---Building ${images[$i]}---"

--- a/utils/apptainer/def/vcf-report-6.0.2.def
+++ b/utils/apptainer/def/vcf-report-6.0.2.def
@@ -8,7 +8,7 @@ From: sif/build/openjdk-17.sif
 %post
     version_major=6
     version_minor=0
-    version_patch=1
+    version_patch=2
 
     # install
     apk update
@@ -16,7 +16,7 @@ From: sif/build/openjdk-17.sif
 
     mkdir -p /opt/vcf-report/lib
     curl -Ls -o /opt/vcf-report/lib/vcf-report.jar "https://github.com/molgenis/vip-report/releases/download/v${version_major}.${version_minor}.${version_patch}/vcf-report.jar"
-    echo "0630bf628d3c9a21c0cada773b8cfcdd5a9a4f94ab494ca53a1b4b63ae458418  /opt/vcf-report/lib/vcf-report.jar" | sha256sum -c
+    echo "7974da48b9ac832cd845437b2ae42366390f100d5ecc591b03d846d689588bc1  /opt/vcf-report/lib/vcf-report.jar" | sha256sum -c
 
     # cleanup
     apk del .build-dependencies

--- a/vip.sh
+++ b/vip.sh
@@ -7,7 +7,7 @@ SCRIPT_NAME="$(basename "$0")"
 # SCRIPT_DIR is incorrect when vip.sh is submitted as a Slurm job that is submitted as part of another Slurm job
 VIP_DIR="${VIP_DIR:-"${SCRIPT_DIR}"}"
 
-VIP_VERSION="7.6.0"
+VIP_VERSION="7.7.0"
 
 display_version() {
   echo -e "${VIP_VERSION}"


### PR DESCRIPTION
```
running tests ...
vcf/aip                                  | PASSED | 215047=completed test/output/vcf/aip/.nxf.log
vcf/chd7                                 | PASSED | 215048=completed test/output/vcf/chd7/.nxf.log
vcf/corner_cases                         | PASSED | 215049=completed test/output/vcf/corner_cases/.nxf.log
vcf/deb_register                         | PASSED | 215050=completed test/output/vcf/deb_register/.nxf.log
vcf/empty_input                          | PASSED | 215051=completed test/output/vcf/empty_input/.nxf.log
vcf/empty_output_filter_samples          | PASSED | 215052=completed test/output/vcf/empty_output_filter_samples/.nxf.log
vcf/empty_output_filter                  | PASSED | 215053=completed test/output/vcf/empty_output_filter/.nxf.log
vcf/filter_samples                       | PASSED | 215054=completed test/output/vcf/filter_samples/.nxf.log
vcf/liftover                             | PASSED | 215055=completed test/output/vcf/liftover/.nxf.log
vcf/multiproject_classify                | PASSED | 215056=completed test/output/vcf/multiproject_classify/.nxf.log
vcf/mvid                                 | PASSED | 215057=completed test/output/vcf/mvid/.nxf.log
vcf/str                                  | PASSED | 215058=completed test/output/vcf/str/.nxf.log
vcf/trio                                 | PASSED | 215059=completed test/output/vcf/trio/.nxf.log
vcf/vkgl_lb                              | PASSED | 215060=completed test/output/vcf/vkgl_lb/.nxf.log
vcf/vkgl_lp                              | PASSED | 215061=completed test/output/vcf/vkgl_lp/.nxf.log
done
```