### PR TITLE
Fix decision tree issues (regarding FLAG and FILE support)

### DIFF
--- a/config/nxf_call_str.config
+++ b/config/nxf_call_str.config
@@ -2,7 +2,7 @@ includeConfig 'nxf.config'
 
 env {
   CMD_EXPANSIONHUNTER = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/expansionhunter-5.0.0.sif ExpansionHunter"
-  CMD_STRAGLR="apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/straglr-1.4.4_vip_v2.sif straglr-genotype"
+  CMD_STRAGLR="apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/straglr-1.4.4_vip_v3.sif straglr-genotype"
 }
 
 params {

--- a/config/nxf_vcf.config
+++ b/config/nxf_vcf.config
@@ -8,7 +8,7 @@ env {
   CMD_FILTERVEP = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vep-111.0.sif filter_vep"
   CMD_STRANGER = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/stranger-0.8.1.sif stranger"
   CMD_VCFREPORT="apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-report-6.0.2.sif"
-  CMD_VCFDECISIONTREE = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-decision-tree-4.0.0.sif"
+  CMD_VCFDECISIONTREE = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-decision-tree-4.1.1.sif"
   CMD_VCFINHERITANCEMATCHER = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-inheritance-matcher-3.1.0.sif"
 
   // workaround for SAMtools https://github.com/samtools/samtools/issues/1366#issuecomment-769170935

--- a/install.sh
+++ b/install.sh
@@ -82,7 +82,7 @@ download_files() {
   urls+=("7486bd5de526d9888df8eea2d8bdea48" "images/minimap2-2.27.sif")
   urls+=("06ac8a76a307fa42fffd80ab906fd24b" "images/picard-3.1.1.sif")
   urls+=("9a4b685b26744113d3ea0a3904c02706" "images/samtools-1.17-patch1.sif")
-  urls+=("FIXME" "images/straglr-1.4.4_vip_v3.sif")
+  urls+=("8f6e06847776448e004df8b863571109" "images/straglr-1.4.4_vip_v3.sif")
   urls+=("bcc157242cd9b09c66f015c52ef2d61d" "images/stranger-0.8.1.sif")
   urls+=("57401e7b835fed2f52fafadc0dd744d4" "images/vcf-decision-tree-4.1.1.sif")
   urls+=("9c4d7b48138f29651cdd45eb8d0cc4b6" "images/vcf-inheritance-matcher-3.1.0.sif")

--- a/install.sh
+++ b/install.sh
@@ -82,7 +82,7 @@ download_files() {
   urls+=("7486bd5de526d9888df8eea2d8bdea48" "images/minimap2-2.27.sif")
   urls+=("06ac8a76a307fa42fffd80ab906fd24b" "images/picard-3.1.1.sif")
   urls+=("9a4b685b26744113d3ea0a3904c02706" "images/samtools-1.17-patch1.sif")
-  urls+=("556d7e6b523e282f9920729edc3d0842" "images/straglr-1.4.4_vip_v2.sif")
+  urls+=("FIXME" "images/straglr-1.4.4_vip_v3.sif")
   urls+=("bcc157242cd9b09c66f015c52ef2d61d" "images/stranger-0.8.1.sif")
   urls+=("57401e7b835fed2f52fafadc0dd744d4" "images/vcf-decision-tree-4.1.1.sif")
   urls+=("9c4d7b48138f29651cdd45eb8d0cc4b6" "images/vcf-inheritance-matcher-3.1.0.sif")

--- a/install.sh
+++ b/install.sh
@@ -84,7 +84,7 @@ download_files() {
   urls+=("9a4b685b26744113d3ea0a3904c02706" "images/samtools-1.17-patch1.sif")
   urls+=("556d7e6b523e282f9920729edc3d0842" "images/straglr-1.4.4_vip_v2.sif")
   urls+=("bcc157242cd9b09c66f015c52ef2d61d" "images/stranger-0.8.1.sif")
-  urls+=("4fbbd8642ead7754cb8cc19740e18175" "images/vcf-decision-tree-4.0.0.sif")
+  urls+=("TODO" "images/vcf-decision-tree-4.1.1.sif")
   urls+=("9c4d7b48138f29651cdd45eb8d0cc4b6" "images/vcf-inheritance-matcher-3.1.0.sif")
   urls+=("7f3c5115f68998067a404c922b2e3b15" "images/vcf-report-6.0.2.sif")
   urls+=("7bffc236a7c65b2b2e2e5f7d64beaa87" "images/vep-111.0.sif")

--- a/install.sh
+++ b/install.sh
@@ -84,7 +84,7 @@ download_files() {
   urls+=("9a4b685b26744113d3ea0a3904c02706" "images/samtools-1.17-patch1.sif")
   urls+=("556d7e6b523e282f9920729edc3d0842" "images/straglr-1.4.4_vip_v2.sif")
   urls+=("bcc157242cd9b09c66f015c52ef2d61d" "images/stranger-0.8.1.sif")
-  urls+=("TODO" "images/vcf-decision-tree-4.1.1.sif")
+  urls+=("57401e7b835fed2f52fafadc0dd744d4" "images/vcf-decision-tree-4.1.1.sif")
   urls+=("9c4d7b48138f29651cdd45eb8d0cc4b6" "images/vcf-inheritance-matcher-3.1.0.sif")
   urls+=("7f3c5115f68998067a404c922b2e3b15" "images/vcf-report-6.0.2.sif")
   urls+=("7bffc236a7c65b2b2e2e5f7d64beaa87" "images/vep-111.0.sif")

--- a/utils/apptainer/build.sh
+++ b/utils/apptainer/build.sh
@@ -94,7 +94,7 @@ main() {
   images+=("samtools-1.17-patch1")
   images+=("stranger-0.8.1")
   images+=("straglr-1.4.4_vip_v2")
-  images+=("vcf-decision-tree-4.0.0")
+  images+=("vcf-decision-tree-4.1.1")
   images+=("vcf-inheritance-matcher-3.1.0")
   images+=("vcf-report-6.0.2")
 

--- a/utils/apptainer/build.sh
+++ b/utils/apptainer/build.sh
@@ -93,7 +93,7 @@ main() {
   images+=("picard-3.1.1")
   images+=("samtools-1.17-patch1")
   images+=("stranger-0.8.1")
-  images+=("straglr-1.4.4_vip_v2")
+  images+=("straglr-1.4.4_vip_v3")
   images+=("vcf-decision-tree-4.1.1")
   images+=("vcf-inheritance-matcher-3.1.0")
   images+=("vcf-report-6.0.2")

--- a/utils/apptainer/def/straglr-1.4.4_vip_v3.def
+++ b/utils/apptainer/def/straglr-1.4.4_vip_v3.def
@@ -11,8 +11,8 @@ From: sif/build/ubuntu-22.04.sif
     curl -Ls -o /opt/trf/trf "https://github.com/Benson-Genomics-Lab/TRF/releases/download/v4.09.1/trf409.linux64"
     chmod +x /opt/trf/trf
 
-    #3e9fbcb77984617151d4010fee087ea423d998f9 == v1.4.4_vip_v2
-    pip install git+https://github.com/molgenis/straglr.git@3e9fbcb77984617151d4010fee087ea423d998f9#egg=straglr
+    #fef64d4240293df0ddae0a190fb20c5ed9c6c129 == v1.4.4_vip_v3
+    pip install git+https://github.com/molgenis/straglr.git@fef64d4240293df0ddae0a190fb20c5ed9c6c129#egg=straglr
 
     # cleanup
     pip cache purge

--- a/utils/apptainer/def/vcf-decision-tree-4.1.1.def
+++ b/utils/apptainer/def/vcf-decision-tree-4.1.1.def
@@ -7,8 +7,8 @@ From: sif/build/openjdk-17.sif
 
 %post
     version_major=4
-    version_minor=0
-    version_patch=0
+    version_minor=1
+    version_patch=1
 
     # install
     apk update
@@ -16,7 +16,7 @@ From: sif/build/openjdk-17.sif
 
     mkdir -p /opt/vcf-decision-tree/lib
     curl -Ls -o /opt/vcf-decision-tree/lib/vcf-decision-tree.jar "https://github.com/molgenis/vip-decision-tree/releases/download/v${version_major}.${version_minor}.${version_patch}/vcf-decision-tree.jar"
-    echo "4029e1d488478a1e71214b352ef17b088bbb9ba3eff86036ef5e0fdf60fad33e  /opt/vcf-decision-tree/lib/vcf-decision-tree.jar" | sha256sum -c
+    echo "TODO  /opt/vcf-decision-tree/lib/vcf-decision-tree.jar" | sha256sum -c
 
     # cleanup
     apk del .build-dependencies

--- a/utils/apptainer/def/vcf-decision-tree-4.1.1.def
+++ b/utils/apptainer/def/vcf-decision-tree-4.1.1.def
@@ -16,7 +16,7 @@ From: sif/build/openjdk-17.sif
 
     mkdir -p /opt/vcf-decision-tree/lib
     curl -Ls -o /opt/vcf-decision-tree/lib/vcf-decision-tree.jar "https://github.com/molgenis/vip-decision-tree/releases/download/v${version_major}.${version_minor}.${version_patch}/vcf-decision-tree.jar"
-    echo "TODO  /opt/vcf-decision-tree/lib/vcf-decision-tree.jar" | sha256sum -c
+    echo "5c18aa3c302bbc4120c0fae50bca99828f7304837a52d96606bea0133a140780  /opt/vcf-decision-tree/lib/vcf-decision-tree.jar" | sha256sum -c
 
     # cleanup
     apk del .build-dependencies

--- a/vip.sh
+++ b/vip.sh
@@ -7,7 +7,7 @@ SCRIPT_NAME="$(basename "$0")"
 # SCRIPT_DIR is incorrect when vip.sh is submitted as a Slurm job that is submitted as part of another Slurm job
 VIP_DIR="${VIP_DIR:-"${SCRIPT_DIR}"}"
 
-VIP_VERSION="7.7.0"
+VIP_VERSION="7.7.1"
 
 display_version() {
   echo -e "${VIP_VERSION}"


### PR DESCRIPTION
vcf/aip                                  | PASSED | 218035=completed output/vcf/aip/.nxf.log
vcf/chd7                                 | PASSED | 218036=completed output/vcf/chd7/.nxf.log
vcf/corner_cases                         | PASSED | 218037=completed output/vcf/corner_cases/.nxf.log
vcf/deb_register                         | PASSED | 218038=completed output/vcf/deb_register/.nxf.log
vcf/empty_input                          | PASSED | 218039=completed output/vcf/empty_input/.nxf.log
vcf/empty_output_filter_samples          | PASSED | 218040=completed output/vcf/empty_output_filter_samples/.nxf.log
vcf/empty_output_filter                  | PASSED | 218041=completed output/vcf/empty_output_filter/.nxf.log
vcf/filter_samples                       | PASSED | 218042=completed output/vcf/filter_samples/.nxf.log
vcf/liftover                             | PASSED | 218043=completed output/vcf/liftover/.nxf.log
vcf/multiproject_classify                | PASSED | 218044=completed output/vcf/multiproject_classify/.nxf.log
vcf/mvid                                 | PASSED | 218045=completed output/vcf/mvid/.nxf.log
vcf/str                                  | PASSED | 218046=completed output/vcf/str/.nxf.log
vcf/trio                                 | PASSED | 218047=completed output/vcf/trio/.nxf.log
vcf/vkgl_lb                              | PASSED | 218048=completed output/vcf/vkgl_lb/.nxf.log
vcf/vkgl_lp                              | PASSED | 218049=completed output/vcf/vkgl_lp/.nxf.log

cram/nanopore_duo                        | PASSED | 218359=completed output/cram/nanopore_duo/.nxf.log
cram/nanopore                            | PASSED | 218360=completed output/cram/nanopore/.nxf.log


End-to-end tests are not executed by Travis CI, please execute manually:
- [x] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 
