### PR TITLE
Fix null exception when no HPO provided

### DIFF
--- a/modules/vcf/utils.nf
+++ b/modules/vcf/utils.nf
@@ -29,7 +29,7 @@ def areProbandHpoIdsIndentical(samples) {
   def hpo_ids=[]
   def isIdentical = true
   getProbands(samples).each{ sample ->
-    if(hpo_ids.isEmpty() && !sample.hpo_ids.isEmpty()){
+    if(hpo_ids.isEmpty() && sample.hpo_ids != null && !sample.hpo_ids.isEmpty){
       hpo_ids = sample.hpo_ids
     }else{
       if(sample.hpo_ids as Set != hpo_ids as Set){


### PR DESCRIPTION
running tests ...
vcf/aip                                  | PASSED | 220315=completed output/vcf/aip/.nxf.log
vcf/chd7                                 | PASSED | 220316=completed output/vcf/chd7/.nxf.log
vcf/corner_cases                         | PASSED | 220317=completed output/vcf/corner_cases/.nxf.log
vcf/deb_register                         | PASSED | 220318=completed output/vcf/deb_register/.nxf.log
vcf/empty_input                          | PASSED | 220319=completed output/vcf/empty_input/.nxf.log
vcf/empty_output_filter_samples          | PASSED | 220320=completed output/vcf/empty_output_filter_samples/.nxf.log
vcf/empty_output_filter                  | PASSED | 220321=completed output/vcf/empty_output_filter/.nxf.log
vcf/filter_samples                       | PASSED | 220322=completed output/vcf/filter_samples/.nxf.log
vcf/liftover                             | PASSED | 220323=completed output/vcf/liftover/.nxf.log
vcf/multiproject_classify                | PASSED | 220324=completed output/vcf/multiproject_classify/.nxf.log
vcf/mvid                                 | PASSED | 220325=completed output/vcf/mvid/.nxf.log
vcf/str                                  | PASSED | 220326=completed output/vcf/str/.nxf.log
vcf/trio                                 | PASSED | 220327=completed output/vcf/trio/.nxf.log
vcf/vkgl_lb                              | PASSED | 220328=completed output/vcf/vkgl_lb/.nxf.log
vcf/vkgl_lp                              | PASSED | 220329=completed output/vcf/vkgl_lp/.nxf.log
done

End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 
