### PR TITLE
fix gnomAD VEP plugin: gnomAD_QC can be incorrect

### DIFF
--- a/resources/vep/plugins/gnomAD.pm
+++ b/resources/vep/plugins/gnomAD.pm
@@ -110,7 +110,7 @@ sub parse_data {
   my @qc;
   if($src eq 'E') {
     @qc = split(/,/, $qc_e);
-  } elsif($src eq 'E') {
+  } elsif($src eq 'G') {
     @qc = split(/,/, $qc_g);
   } else {
     @qc = uniq(split(/,/, $qc_e . ',' . $qc_g));

--- a/test/suites/vcf/vkgl_lb.sh
+++ b/test/suites/vcf/vkgl_lb.sh
@@ -11,7 +11,7 @@ args+=("--resume")
 vip "${args[@]}" 1> /dev/null
 
 # compare expected to actual output and store result
-if [ ! "$(zcat "${OUTPUT_DIR}/vip.vcf.gz" | grep -vc "^#")" -gt 3625 ]; then
+if [ ! "$(zcat "${OUTPUT_DIR}/vip.vcf.gz" | grep -vc "^#")" -gt 3596 ]; then
   result="0"
 else
   result="1"


### PR DESCRIPTION
```
running tests ...
vcf/vkgl_lb                              | PASSED | 223534=completed test/output/vcf/vkgl_lb/.nxf.log
vcf/vkgl_lp                              | PASSED | 223535=completed test/output/vcf/vkgl_lp/.nxf.log
done
```