### PR TITLE
Produce cram coverage and read depth intermediate outputs

### DIFF
--- a/modules/cram/coverage.nf
+++ b/modules/cram/coverage.nf
@@ -1,0 +1,28 @@
+process coverage {
+  label 'coverage'
+  
+  publishDir "$params.output/intermediates", mode: 'link'
+
+  input:
+    tuple val(meta), path(cram), path(cramCrai)
+  
+  output:
+    tuple val(meta), path(cramCoverageOut), path(cramDepthOut)
+  
+  shell:
+    cramCoverageOut="${meta.project.id}_${meta.sample.family_id}_${meta.sample.individual_id}_coverage.tsv.gz"
+    cramDepthOut="${meta.project.id}_${meta.sample.family_id}_${meta.sample.individual_id}_depth.tsv.gz"
+
+    paramReference = params[meta.project.assembly].reference.fasta
+
+    template 'coverage.sh'
+  
+  stub:
+    cramCoverageOut="${meta.project.id}_${meta.sample.family_id}_${meta.sample.individual_id}_coverage.tsv.gz"
+		cramDepthOut="${meta.project.id}_${meta.sample.family_id}_${meta.sample.individual_id}_depth.tsv.gz"
+
+    """
+    touch "${cramCoverageOut}"
+    touch "${cramDepthOut}"
+    """
+}

--- a/modules/cram/templates/coverage.sh
+++ b/modules/cram/templates/coverage.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+coverage () {
+  ${CMD_SAMTOOLS} coverage --reference "!{paramReference}" "!{cram}" | gzip "!{cramCoverageOut}"
+}
+
+depth () {
+  ${CMD_SAMTOOLS} depth --reference "!{paramReference}" "!{cram}" | gzip > "!{cramDepthOut}"
+}
+
+main() {
+  coverage
+  depth
+}
+
+main "$@"

--- a/modules/cram/templates/coverage.sh
+++ b/modules/cram/templates/coverage.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 coverage () {
-  ${CMD_SAMTOOLS} coverage --reference "!{paramReference}" "!{cram}" | gzip "!{cramCoverageOut}"
+  ${CMD_SAMTOOLS} coverage --reference "!{paramReference}" "!{cram}" | gzip > "!{cramCoverageOut}"
 }
 
 depth () {

--- a/vip_cram.nf
+++ b/vip_cram.nf
@@ -8,6 +8,7 @@ include { snv; validateCallSnvParams } from './subworkflows/call_snv'
 include { str; validateCallStrParams } from './subworkflows/call_str'
 include { sv; validateCallSvParams } from './subworkflows/call_sv'
 include { concat_vcf } from './modules/cram/concat_vcf'
+include { coverage } from './modules/cram/coverage'
 
 /**
  * input:  [project, sample, ...]
@@ -21,10 +22,15 @@ workflow cram {
     if(params.cram.call_str) ++nrActivateVariantCallerTypes;
     if(params.cram.call_sv)  ++nrActivateVariantCallerTypes;
 
-    // output pre-preprocessed crams to snv, str and sv channels
+    // output pre-preprocessed crams to coverage, snv, str and sv channels
     meta
-      | multiMap { it -> snv: str: sv: it }
+      | multiMap { it -> coverage: snv: str: sv: it }
       | set { ch_cram_multi }
+
+		// coverage
+		ch_cram_multi.coverage
+		  | map { meta -> [meta, meta.sample.cram.data, meta.sample.cram.index] }
+		  | coverage
 
     // snv
     ch_cram_multi.snv

--- a/vip_fastq.nf
+++ b/vip_fastq.nf
@@ -70,12 +70,6 @@ workflow fastq {
 
     ch_input_paired_end_aligned.mix(ch_input_single_aligned)
       | merge_cram
-      | multiMap { it -> done: coverage: it }
-      | set { ch_input_aligned }
-
-    ch_input_aligned.coverage
-      | 
-    ch_input_aligned.done
       | map { meta, cram, cramIndex, cramStats -> [*:meta, project: [*:meta.project, assembly: params.assembly], sample: [*:meta.sample, cram: [data: cram, index: cramIndex, stats: cramStats]]] }
       | cram
 }

--- a/vip_fastq.nf
+++ b/vip_fastq.nf
@@ -70,6 +70,12 @@ workflow fastq {
 
     ch_input_paired_end_aligned.mix(ch_input_single_aligned)
       | merge_cram
+      | multiMap { it -> done: coverage: it }
+      | set { ch_input_aligned }
+
+    ch_input_aligned.coverage
+      | 
+    ch_input_aligned.done
       | map { meta, cram, cramIndex, cramStats -> [*:meta, project: [*:meta.project, assembly: params.assembly], sample: [*:meta.sample, cram: [data: cram, index: cramIndex, stats: cramStats]]] }
       | cram
 }


### PR DESCRIPTION
```
running tests ...
cram/complex                             | PASSED | 225734=completed test/output/cram/complex/.nxf.log
cram/multiproject                        | PASSED | 225735=completed test/output/cram/multiproject/.nxf.log
cram/nanopore_duo                        | PASSED | 225736=completed test/output/cram/nanopore_duo/.nxf.log
cram/nanopore                            | PASSED | 225737=completed test/output/cram/nanopore/.nxf.log
cram/single                              | PASSED | 225738=completed test/output/cram/single/.nxf.log
cram/trio                                | PASSED | 225739=completed test/output/cram/trio/.nxf.log
fastq/nanopore                           | PASSED | 225740=completed test/output/fastq/nanopore/.nxf.log
fastq/pacbio_hifi                        | PASSED | 225741=completed test/output/fastq/pacbio_hifi/.nxf.log
done
```