### PR TITLE
bump Nextflow 23.10.0 to 24.04.2

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -88,7 +88,7 @@ download_files() {
   urls+=("9c4d7b48138f29651cdd45eb8d0cc4b6" "images/vcf-inheritance-matcher-3.1.0.sif")
   urls+=("7f3c5115f68998067a404c922b2e3b15" "images/vcf-report-6.0.2.sif")
   urls+=("7bffc236a7c65b2b2e2e5f7d64beaa87" "images/vep-111.0.sif")
-  urls+=("b1ece372a2c4db0c57a204d5a6175eb9" "nextflow-23.10.0-all")
+  urls+=("82be3c18406e7c027ee4cec83a723d71" "nextflow-24.04.2-all")
   if [ "${assembly}" == "ALL" ] || [ "${assembly}" == "GRCh37" ]; then
     urls+=("11b8eb3d28482729dd035458ad5bda01" "resources/GRCh37/human_g1k_v37.fasta.gz")
     urls+=("772484cc07983aba1355c7fb50f176d4" "resources/GRCh37/human_g1k_v37.fasta.gz.fai")
@@ -191,7 +191,7 @@ create_symlinks() {
   local -r output_dir="${1}"
 
   # update utils/install.sh when updating nextflow
-  local -r file="nextflow-23.10.0-all"
+  local -r file="nextflow-24.04.2-all"
   (cd "${output_dir}" && chmod +x "${file}") || echo "Failed to set permissions for ${file}"
   (cd "${output_dir}" && rm -f nextflow && ln -s ${file} "nextflow")
 

--- a/utils/install.sh
+++ b/utils/install.sh
@@ -59,8 +59,8 @@ install() {
   ln -s "${SCRIPT_DIR}/resources/gado" "${versionDir}/resources/gado"
 
   # prevent downloading shared resource
-  if [ -f "${SCRIPT_DIR}/resources/nextflow-23.10.0-all" ]; then
-    cp --link "${SCRIPT_DIR}/resources/nextflow-23.10.0-all" "${versionDir}"
+  if [ -f "${SCRIPT_DIR}/resources/nextflow-24.04.2-all" ]; then
+    cp --link "${SCRIPT_DIR}/resources/nextflow-24.04.2-all" "${versionDir}"
   fi
   if [ -f "${SCRIPT_DIR}/resources/hpo_20240404.tsv" ]; then
     cp --link "${SCRIPT_DIR}/resources/hpo_20240404.tsv" "${versionDir}/resources"
@@ -76,8 +76,8 @@ install() {
   fi
 
   # make resource shared
-  if [ -f "${versionDir}/nextflow-23.10.0-all" ] && [ ! -f "${SCRIPT_DIR}/resources/nextflow-23.10.0-all" ]; then
-    cp --link "${versionDir}/nextflow-23.10.0-all" "${SCRIPT_DIR}/resources"
+  if [ -f "${versionDir}/nextflow-24.04.2-all" ] && [ ! -f "${SCRIPT_DIR}/resources/nextflow-24.04.2-all" ]; then
+    cp --link "${versionDir}/nextflow-24.04.2-all" "${SCRIPT_DIR}/resources"
   fi
   if [ -f "${versionDir}/resources/hpo_20240404.tsv" ] && [ ! -f "${SCRIPT_DIR}/resources/hpo_20240404.tsv" ]; then
     cp --link "${versionDir}/resources/hpo_20240404.tsv" "${SCRIPT_DIR}/resources"

--- a/vip.sh
+++ b/vip.sh
@@ -152,7 +152,7 @@ execute_workflow() {
   if [[ "${paramStub}" == "true" ]]; then
     args+=("-stub")
   fi
-  (cd "${paramOutput}" && APPTAINER_BIND="${APPTAINER_BIND-${envBind}}" APPTAINER_CACHEDIR="${envCacheDir}" NXF_VER="23.10.0" NXF_HOME="${envHome}" NXF_TEMP="${envTemp}" NXF_WORK="${envWork}" NXF_ENABLE_STRICT="${envStrict}" NXF_JVM_ARGS="${envJvm}" VIP_VERSION="${VIP_VERSION}" "${VIP_DIR}/nextflow" "${args[@]}")
+  (cd "${paramOutput}" && APPTAINER_BIND="${APPTAINER_BIND-${envBind}}" APPTAINER_CACHEDIR="${envCacheDir}" NXF_VER="24.04.2" NXF_HOME="${envHome}" NXF_TEMP="${envTemp}" NXF_WORK="${envWork}" NXF_ENABLE_STRICT="${envStrict}" NXF_JVM_ARGS="${envJvm}" VIP_VERSION="${VIP_VERSION}" "${VIP_DIR}/nextflow" "${args[@]}")
 }
 
 main() {


### PR DESCRIPTION
```
running tests ...
vcf/aip                                  | PASSED | 226457=completed test/output/vcf/aip/.nxf.log
vcf/chd7                                 | PASSED | 226458=completed test/output/vcf/chd7/.nxf.log
vcf/corner_cases                         | PASSED | 226459=completed test/output/vcf/corner_cases/.nxf.log
vcf/deb_register                         | PASSED | 226460=completed test/output/vcf/deb_register/.nxf.log
vcf/empty_input                          | PASSED | 226461=completed test/output/vcf/empty_input/.nxf.log
vcf/empty_output_filter_samples          | PASSED | 226462=completed test/output/vcf/empty_output_filter_samples/.nxf.log
vcf/empty_output_filter                  | PASSED | 226463=completed test/output/vcf/empty_output_filter/.nxf.log
vcf/filter_samples                       | PASSED | 226464=completed test/output/vcf/filter_samples/.nxf.log
vcf/liftover                             | PASSED | 226465=completed test/output/vcf/liftover/.nxf.log
vcf/multiproject_classify                | PASSED | 226466=completed test/output/vcf/multiproject_classify/.nxf.log
vcf/mvid                                 | PASSED | 226467=completed test/output/vcf/mvid/.nxf.log
vcf/str                                  | PASSED | 226468=completed test/output/vcf/str/.nxf.log
vcf/trio                                 | PASSED | 226469=completed test/output/vcf/trio/.nxf.log
vcf/vkgl_lb                              | FAILED | 226470=completed test/output/vcf/vkgl_lb/.nxf.log
vcf/vkgl_lp                              | PASSED | 226471=completed test/output/vcf/vkgl_lp/.nxf.log
vcf/vkgl_vus                             | PASSED | 226472=completed test/output/vcf/vkgl_vus/.nxf.log
done
```