### PR TITLE
bump vip-report 6.0.2 to 6.1.0

### DIFF
--- a/config/nxf_vcf.config
+++ b/config/nxf_vcf.config
@@ -7,7 +7,7 @@ env {
   CMD_VEP = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vep-111.0.sif vep"
   CMD_FILTERVEP = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vep-111.0.sif filter_vep"
   CMD_STRANGER = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/stranger-0.8.1.sif stranger"
-  CMD_VCFREPORT="apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-report-6.0.2.sif"
+  CMD_VCFREPORT="apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-report-6.1.0.sif"
   CMD_VCFDECISIONTREE = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-decision-tree-4.1.1.sif"
   CMD_VCFINHERITANCEMATCHER = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-inheritance-matcher-3.1.0.sif"
 

--- a/install.sh
+++ b/install.sh
@@ -87,7 +87,7 @@ download_files() {
   urls+=("bcc157242cd9b09c66f015c52ef2d61d" "images/stranger-0.8.1.sif")
   urls+=("57401e7b835fed2f52fafadc0dd744d4" "images/vcf-decision-tree-4.1.1.sif")
   urls+=("9c4d7b48138f29651cdd45eb8d0cc4b6" "images/vcf-inheritance-matcher-3.1.0.sif")
-  urls+=("7f3c5115f68998067a404c922b2e3b15" "images/vcf-report-6.1.0.sif") #FIXME update checksum
+  urls+=("7d63b12606eba4775da78b2990a403df" "images/vcf-report-6.1.0.sif")
   urls+=("7bffc236a7c65b2b2e2e5f7d64beaa87" "images/vep-111.0.sif")
   urls+=("82be3c18406e7c027ee4cec83a723d71" "nextflow-24.04.2-all")
   if [ "${assembly}" == "ALL" ] || [ "${assembly}" == "GRCh37" ]; then

--- a/install.sh
+++ b/install.sh
@@ -87,7 +87,7 @@ download_files() {
   urls+=("bcc157242cd9b09c66f015c52ef2d61d" "images/stranger-0.8.1.sif")
   urls+=("57401e7b835fed2f52fafadc0dd744d4" "images/vcf-decision-tree-4.1.1.sif")
   urls+=("9c4d7b48138f29651cdd45eb8d0cc4b6" "images/vcf-inheritance-matcher-3.1.0.sif")
-  urls+=("7f3c5115f68998067a404c922b2e3b15" "images/vcf-report-6.0.2.sif")
+  urls+=("7f3c5115f68998067a404c922b2e3b15" "images/vcf-report-6.1.0.sif") #FIXME update checksum
   urls+=("7bffc236a7c65b2b2e2e5f7d64beaa87" "images/vep-111.0.sif")
   urls+=("82be3c18406e7c027ee4cec83a723d71" "nextflow-24.04.2-all")
   if [ "${assembly}" == "ALL" ] || [ "${assembly}" == "GRCh37" ]; then
@@ -143,7 +143,6 @@ download_files() {
   urls+=("df31eb0fe9ebd9ae26c8d6f5f7ba6e57" "resources/inheritance_20240115.tsv")
   urls+=("7138e76a38d6f67935699d06082ecacf" "resources/vep/cache/homo_sapiens_refseq_vep_111_GRCh38.tar.gz")
   # when modifying urls array, please keep list in 'ls -l' order
-
   for ((i = 0; i < ${#urls[@]}; i += 2)); do
     download_file "${base_url}" "${urls[i+1]}" "${urls[i+0]}" "${output_dir}" "${validate}"
   done

--- a/utils/apptainer/build.sh
+++ b/utils/apptainer/build.sh
@@ -97,7 +97,7 @@ main() {
   images+=("straglr-1.4.4_vip_v3")
   images+=("vcf-decision-tree-4.1.1")
   images+=("vcf-inheritance-matcher-3.1.0")
-  images+=("vcf-report-6.0.2")
+  images+=("vcf-report-6.1.0")
 
   for i in "${!images[@]}"; do
     echo "---Building ${images[$i]}---"

--- a/utils/apptainer/def/vcf-report-6.1.0.def
+++ b/utils/apptainer/def/vcf-report-6.1.0.def
@@ -7,8 +7,8 @@ From: sif/build/openjdk-17.sif
 
 %post
     version_major=6
-    version_minor=0
-    version_patch=2
+    version_minor=1
+    version_patch=0
 
     # install
     apk update
@@ -16,7 +16,7 @@ From: sif/build/openjdk-17.sif
 
     mkdir -p /opt/vcf-report/lib
     curl -Ls -o /opt/vcf-report/lib/vcf-report.jar "https://github.com/molgenis/vip-report/releases/download/v${version_major}.${version_minor}.${version_patch}/vcf-report.jar"
-    echo "7974da48b9ac832cd845437b2ae42366390f100d5ecc591b03d846d689588bc1  /opt/vcf-report/lib/vcf-report.jar" | sha256sum -c
+    echo "c7c540e3df0e381a086c18cf1a0da015c23336ff14ba1f5a0b6291ba51f37ce9  /opt/vcf-report/lib/vcf-report.jar" | sha256sum -c
 
     # cleanup
     apk del .build-dependencies


### PR DESCRIPTION
```
running tests ...
vcf/aip                                  | PASSED | 234916=completed test/output/vcf/aip/.nxf.log
vcf/chd7                                 | PASSED | 234917=completed test/output/vcf/chd7/.nxf.log
vcf/corner_cases                         | PASSED | 234918=completed test/output/vcf/corner_cases/.nxf.log
vcf/deb_register                         | PASSED | 234919=completed test/output/vcf/deb_register/.nxf.log
vcf/empty_input                          | PASSED | 234920=completed test/output/vcf/empty_input/.nxf.log
vcf/empty_output_filter_samples          | PASSED | 234921=completed test/output/vcf/empty_output_filter_samples/.nxf.log
vcf/empty_output_filter                  | PASSED | 234922=completed test/output/vcf/empty_output_filter/.nxf.log
vcf/filter_samples                       | PASSED | 234923=completed test/output/vcf/filter_samples/.nxf.log
vcf/liftover                             | PASSED | 234924=completed test/output/vcf/liftover/.nxf.log
vcf/multiproject_classify                | PASSED | 234925=completed test/output/vcf/multiproject_classify/.nxf.log
vcf/mvid                                 | PASSED | 234926=completed test/output/vcf/mvid/.nxf.log
vcf/str                                  | PASSED | 234927=completed test/output/vcf/str/.nxf.log
vcf/trio                                 | PASSED | 234928=completed test/output/vcf/trio/.nxf.log
vcf/vkgl_lb                              | PASSED | 234929=completed test/output/vcf/vkgl_lb/.nxf.log
vcf/vkgl_lp                              | PASSED | 234930=completed test/output/vcf/vkgl_lp/.nxf.log
vcf/vkgl_vus                             | PASSED | 234931=completed test/output/vcf/vkgl_vus/.nxf.log
done
```