### PR TITLE
update fastq config: set 'filter_reads' cpus to 1

### DIFF
--- a/config/nxf_fastq.config
+++ b/config/nxf_fastq.config
@@ -7,6 +7,10 @@ env {
 }
 
 process {
+	withLabel: 'filter_reads' {
+		cpus = 1
+  }
+
   withLabel: 'minimap2_align|minimap2_align_paired_end' {
     cpus = 8
     memory = '32GB'


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 
