### PR TITLE
Bump vip report to v7.0.0 (add sample tree to report)

### DIFF
--- a/config/nxf_vcf.config
+++ b/config/nxf_vcf.config
@@ -111,7 +111,7 @@ params {
       include_crams = true
       max_records = ""
       max_samples = ""
-      template = ""
+      template = "${projectDir}/resources/vip-report-template-v6.1.1.html"
 			metadata = "${projectDir}/resources/field_metadata.json"
 
       GRCh38 {

--- a/config/nxf_vcf.config
+++ b/config/nxf_vcf.config
@@ -111,7 +111,7 @@ params {
       include_crams = true
       max_records = ""
       max_samples = ""
-      template = "${projectDir}/resources/vip-report-template-v6.1.1.html"
+      template = "${projectDir}/resources/vip-report-template-v6.2.0.html"
 			metadata = "${projectDir}/resources/field_metadata.json"
 
       GRCh38 {

--- a/config/nxf_vcf.config
+++ b/config/nxf_vcf.config
@@ -7,7 +7,7 @@ env {
   CMD_VEP = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vep-111.0.sif vep"
   CMD_FILTERVEP = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vep-111.0.sif filter_vep"
   CMD_STRANGER = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/stranger-0.8.1.sif stranger"
-  CMD_VCFREPORT="apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-report-6.1.0.sif"
+  CMD_VCFREPORT="apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-report-7.0.0.sif"
   CMD_VCFDECISIONTREE = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-decision-tree-4.1.1.sif"
   CMD_VCFINHERITANCEMATCHER = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-inheritance-matcher-3.1.0.sif"
 

--- a/install.sh
+++ b/install.sh
@@ -142,6 +142,7 @@ download_files() {
   # update utils/install.sh when updating inheritance.tsv
   urls+=("df31eb0fe9ebd9ae26c8d6f5f7ba6e57" "resources/inheritance_20240115.tsv")
   urls+=("7138e76a38d6f67935699d06082ecacf" "resources/vep/cache/homo_sapiens_refseq_vep_111_GRCh38.tar.gz")
+  urls+=("e800da258a85956724abcc77c125c8f6" "resources/vip-report-template-v6.1.1.html")
   # when modifying urls array, please keep list in 'ls -l' order
   for ((i = 0; i < ${#urls[@]}; i += 2)); do
     download_file "${base_url}" "${urls[i+1]}" "${urls[i+0]}" "${output_dir}" "${validate}"

--- a/install.sh
+++ b/install.sh
@@ -87,7 +87,7 @@ download_files() {
   urls+=("bcc157242cd9b09c66f015c52ef2d61d" "images/stranger-0.8.1.sif")
   urls+=("57401e7b835fed2f52fafadc0dd744d4" "images/vcf-decision-tree-4.1.1.sif")
   urls+=("9c4d7b48138f29651cdd45eb8d0cc4b6" "images/vcf-inheritance-matcher-3.1.0.sif")
-  urls+=("7d63b12606eba4775da78b2990a403df" "images/vcf-report-6.1.0.sif")
+  urls+=("TODO" "images/vcf-report-7.0.0.sif")
   urls+=("7bffc236a7c65b2b2e2e5f7d64beaa87" "images/vep-111.0.sif")
   urls+=("82be3c18406e7c027ee4cec83a723d71" "nextflow-24.04.2-all")
   if [ "${assembly}" == "ALL" ] || [ "${assembly}" == "GRCh37" ]; then

--- a/install.sh
+++ b/install.sh
@@ -142,7 +142,7 @@ download_files() {
   # update utils/install.sh when updating inheritance.tsv
   urls+=("df31eb0fe9ebd9ae26c8d6f5f7ba6e57" "resources/inheritance_20240115.tsv")
   urls+=("7138e76a38d6f67935699d06082ecacf" "resources/vep/cache/homo_sapiens_refseq_vep_111_GRCh38.tar.gz")
-  urls+=("e800da258a85956724abcc77c125c8f6" "resources/vip-report-template-v6.1.1.html")
+  urls+=("78962f0c7c6fe5c63ef7c66b627c95a0" "resources/vip-report-template-v6.2.0.html")
   # when modifying urls array, please keep list in 'ls -l' order
   for ((i = 0; i < ${#urls[@]}; i += 2)); do
     download_file "${base_url}" "${urls[i+1]}" "${urls[i+0]}" "${output_dir}" "${validate}"

--- a/install.sh
+++ b/install.sh
@@ -87,7 +87,7 @@ download_files() {
   urls+=("bcc157242cd9b09c66f015c52ef2d61d" "images/stranger-0.8.1.sif")
   urls+=("57401e7b835fed2f52fafadc0dd744d4" "images/vcf-decision-tree-4.1.1.sif")
   urls+=("9c4d7b48138f29651cdd45eb8d0cc4b6" "images/vcf-inheritance-matcher-3.1.0.sif")
-  urls+=("TODO" "images/vcf-report-7.0.0.sif")
+  urls+=("53f9265acb2041b2b93c692177d91d74" "images/vcf-report-7.0.0.sif")
   urls+=("7bffc236a7c65b2b2e2e5f7d64beaa87" "images/vep-111.0.sif")
   urls+=("82be3c18406e7c027ee4cec83a723d71" "nextflow-24.04.2-all")
   if [ "${assembly}" == "ALL" ] || [ "${assembly}" == "GRCh37" ]; then

--- a/modules/vcf/report.nf
+++ b/modules/vcf/report.nf
@@ -23,6 +23,7 @@ process report {
     refSeqPath = params[meta.project.assembly].reference.fasta
     metadata = params.vcf.classify_samples.metadata
     decisionTree = params.vcf.classify[meta.project.assembly].decision_tree
+    sampleTree = params.vcf.classify_samples[meta.project.assembly].decision_tree
     maxRecords = params.vcf.report.max_records
     maxSamples = params.vcf.report.max_samples
     genesPath = params.vcf.report[meta.project.assembly].genes

--- a/modules/vcf/templates/report.sh
+++ b/modules/vcf/templates/report.sh
@@ -45,6 +45,9 @@ report() {
   if [ -n "!{decisionTree}" ]; then
     args+=("--decision_tree" "!{decisionTree}")
   fi
+  if [ -n "!{sampleTree}" ]; then
+    args+=("--sample_tree" "!{sampleTree}")
+  fi
   if [ -n "!{maxRecords}" ]; then
     args+=("--max_records" "!{maxRecords}")
   fi

--- a/utils/apptainer/build.sh
+++ b/utils/apptainer/build.sh
@@ -97,7 +97,7 @@ main() {
   images+=("straglr-1.4.4_vip_v3")
   images+=("vcf-decision-tree-4.1.1")
   images+=("vcf-inheritance-matcher-3.1.0")
-  images+=("vcf-report-6.1.0")
+  images+=("vcf-report-7.0.0")
 
   for i in "${!images[@]}"; do
     echo "---Building ${images[$i]}---"

--- a/utils/apptainer/def/vcf-report-7.0.0.def
+++ b/utils/apptainer/def/vcf-report-7.0.0.def
@@ -6,8 +6,8 @@ From: sif/build/openjdk-17.sif
     Usage: java -jar /opt/vcf-report/lib/vcf-report.jar
 
 %post
-    version_major=6
-    version_minor=1
+    version_major=7
+    version_minor=0
     version_patch=0
 
     # install
@@ -16,7 +16,7 @@ From: sif/build/openjdk-17.sif
 
     mkdir -p /opt/vcf-report/lib
     curl -Ls -o /opt/vcf-report/lib/vcf-report.jar "https://github.com/molgenis/vip-report/releases/download/v${version_major}.${version_minor}.${version_patch}/vcf-report.jar"
-    echo "c7c540e3df0e381a086c18cf1a0da015c23336ff14ba1f5a0b6291ba51f37ce9  /opt/vcf-report/lib/vcf-report.jar" | sha256sum -c
+    echo "0178acabe55a8c69988abb0e656977f5b7c0c5762e27022f897d9839c34fabfb  /opt/vcf-report/lib/vcf-report.jar" | sha256sum -c
 
     # cleanup
     apk del .build-dependencies


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 

vcf/aip                                  | PASSED | 242227=completed output/vcf/aip/.nxf.log
vcf/chd7                                 | PASSED | 242228=completed output/vcf/chd7/.nxf.log
vcf/corner_cases                         | PASSED | 242229=completed output/vcf/corner_cases/.nxf.log
vcf/deb_register                         | PASSED | 242230=completed output/vcf/deb_register/.nxf.log
vcf/empty_input                          | PASSED | 242231=completed output/vcf/empty_input/.nxf.log
vcf/empty_output_filter_samples          | PASSED | 242232=completed output/vcf/empty_output_filter_samples/.nxf.log
vcf/empty_output_filter                  | PASSED | 242233=completed output/vcf/empty_output_filter/.nxf.log
vcf/filter_samples                       | PASSED | 242234=completed output/vcf/filter_samples/.nxf.log
vcf/liftover                             | PASSED | 242235=completed output/vcf/liftover/.nxf.log
vcf/multiproject_classify                | PASSED | 242236=completed output/vcf/multiproject_classify/.nxf.log
vcf/mvid                                 | PASSED | 242237=completed output/vcf/mvid/.nxf.log
vcf/str                                  | PASSED | 242238=completed output/vcf/str/.nxf.log
vcf/trio                                 | PASSED | 242239=completed output/vcf/trio/.nxf.log
vcf/vkgl_lb                              | PASSED | 242240=completed output/vcf/vkgl_lb/.nxf.log
vcf/vkgl_lp                              | PASSED | 242241=completed output/vcf/vkgl_lp/.nxf.log
vcf/vkgl_vus                             | PASSED | 242242=completed output/vcf/vkgl_vus/.nxf.log
