### PR TITLE
Fix #632 .cram not published in fastq workflow

### DIFF
--- a/modules/fastq/minimap2.nf
+++ b/modules/fastq/minimap2.nf
@@ -1,6 +1,8 @@
 process minimap2_align {
   label 'minimap2_align'
 
+  publishDir "$params.output/intermediates", mode: 'link'
+
   input:
     tuple val(meta), path(fastq, arity: '1')
 
@@ -37,6 +39,8 @@ process minimap2_align {
 process minimap2_align_paired_end {
   label 'minimap2_align_paired_end'
 
+  publishDir "$params.output/intermediates", mode: 'link'
+  
   input:
     tuple val(meta), path(fastqR1, arity: '1'), path(fastqR2, arity: '1')
 

--- a/test/suites/fastq/nanopore_adaptive_sampling.sh
+++ b/test/suites/fastq/nanopore_adaptive_sampling.sh
@@ -23,7 +23,12 @@ vip "${args[@]}" 1> /dev/null
 
 # compare expected to actual output and store result
 if [ "$(zcat "${OUTPUT_DIR}/vip.vcf.gz" | grep -vc "^#")" -gt 0 ]; then
-  result="0"
+  # check if intermediate cram was published
+  if [ -f "${OUTPUT_DIR}/intermediates/vip_fam0_HG002.cram" ]; then
+    result="0"
+  else
+    result="1"
+  fi
 else
   result="1"
 fi


### PR DESCRIPTION
```
running tests ...
fastq/nanopore_adaptive_sampling         | PASSED | 260926=completed test/output/fastq/nanopore_adaptive_sampling/.nxf.log
done
```

```
[umcg-dhendriksen@betabarrel cram_publish]$ ll test/output/fastq/nanopore_adaptive_sampling/intermediates/
...
-rw-rw-r--. 2 umcg-dhendriksen umcg-vipt  28839397 Aug 21 07:44 vip_fam0_HG002.cram
-rw-rw-r--. 2 umcg-dhendriksen umcg-vipt      1025 Aug 21 07:44 vip_fam0_HG002.cram.crai
-rw-rw-r--. 2 umcg-dhendriksen umcg-vipt      5346 Aug 21 07:44 vip_fam0_HG002.cram.stats
...
```