### PR TITLE
Calculate coverage using mosdepth and regions file

### DIFF
--- a/docs/about/acknowledgements.md
+++ b/docs/about/acknowledgements.md
@@ -21,6 +21,7 @@ Standing on the shoulders of giants. This project could not have possible withou
 - [VKGL](https://vkgl.molgeniscloud.org/)
 - [phyloP](http://compgen.cshl.edu/phast)
 - [cuteSV](https://github.com/tjiangHIT/cuteSV)
+- [Mosdepth](https://github.com/brentp/mosdepth)
 - [Spectre](https://github.com/fritzsedlazeck/Spectre)
 - [Straglr](https://github.com/philres/straglr)
 - [Stranger](https://github.com/Clinical-Genomics/stranger)

--- a/docs/usage/workflow.md
+++ b/docs/usage/workflow.md
@@ -20,15 +20,16 @@ The `cram` workflow consists of the following steps:
 
 1. Parallelize sample sheet per sample and for each sample
 2. Create validated, indexed `.bam` file from `bam/cram/sam` input
-3. Discover short tandem repeats and publish as intermediate result.
+4. If a bed file was provide via the sample sheet: generate coverage metrics using [MosDepth](https://github.com/brentp/mosdepth)
+5. Discover short tandem repeats and publish as intermediate result.
     1. Using [ExpansionHunter](https://github.com/Illumina/ExpansionHunter) for Illumina short read data.
     2. Using this [fork of Straglr](https://github.com/molgenis/straglr) for PacBio and Nanopore long read data, this is a fork of this fork(https://github.com/philres/straglr) and is chosen over the original [Straglr](https://github.com/bcgsc/straglr) because of the VCF output that enables VIP to combine it with the SV and SNV data in the VCF workflow.
-4. Discover copy number variants for for PacBio and Nanopore long read data using [Spectre](https://github.com/fritzsedlazeck/Spectre) data and publish as intermediate result.
-5. Parallelize cram in chunks consisting of one or more contigs and for each chunk
+6. Discover copy number variants for for PacBio and Nanopore long read data using [Spectre](https://github.com/fritzsedlazeck/Spectre) data and publish as intermediate result.
+7. Parallelize cram in chunks consisting of one or more contigs and for each chunk
     1. Perform short variant calling with [DeepVariant](https://github.com/google/deepvariant) producing a `gvcf` file per chunk per sample, the gvcfs of the samples in a project are than merged to one vcf per project (using [GLnexus](https://github.com/dnanexus-rnd/GLnexus).
     2. Perform structural variant calling with [Manta](https://github.com/Illumina/manta) or [cuteSV](https://github.com/tjiangHIT/cuteSV) producing a `vcf` file per chunk per project.
-6. Concatenate short variant calling and structural variant calling `vcf` files per chunk per sample
-7. Continue with step 3. of the `vcf` workflow
+8. Concatenate short variant calling and structural variant calling `vcf` files per chunk per sample
+9. Continue with step 3. of the `vcf` workflow
 
 For details, see [here](https://github.com/molgenis/vip/blob/main/vip_cram.nf).
 

--- a/modules/cram/coverage.nf
+++ b/modules/cram/coverage.nf
@@ -4,25 +4,46 @@ process coverage {
   publishDir "$params.output/intermediates", mode: 'link'
 
   input:
-    tuple val(meta), path(cram), path(cramCrai)
+    tuple val(meta), path(cram), path(cramCrai), path(regions)
   
   output:
-    tuple val(meta), path(cramCoverageOut), path(cramDepthOut)
+    tuple val(meta), path(mosdepth_global), path(mosdepth_region),path(mosdepth_summary), path(mosdepth_per_base_bed),path(mosdepth_per_base_bed_csi), path(mosdepth_regions_bed), path(mosdepth_regions_bed_csi), path(mosdepth_thresholds_bed), path(mosdepth_thresholds_bed_csi)
   
   shell:
-    cramCoverageOut="${meta.project.id}_${meta.sample.family_id}_${meta.sample.individual_id}_coverage.tsv.gz"
-    cramDepthOut="${meta.project.id}_${meta.sample.family_id}_${meta.sample.individual_id}_depth.tsv.gz"
+    mosdepth_global = "${meta.project.id}_${meta.sample.family_id}_${meta.sample.individual_id}_mosdepth.global.dist.txt"
+    mosdepth_region = "${meta.project.id}_${meta.sample.family_id}_${meta.sample.individual_id}_mosdepth.region.dist.txt"
+    mosdepth_summary = "${meta.project.id}_${meta.sample.family_id}_${meta.sample.individual_id}_mosdepth.summary.txt"
+    mosdepth_per_base_bed = "${meta.project.id}_${meta.sample.family_id}_${meta.sample.individual_id}_mosdepth.per-base.bed.gz"
+    mosdepth_per_base_bed_csi = "${meta.project.id}_${meta.sample.family_id}_${meta.sample.individual_id}_mosdepth.per-base.bed.gz.csi"
+    mosdepth_regions_bed = "${meta.project.id}_${meta.sample.family_id}_${meta.sample.individual_id}_mosdepth.regions.bed.gz"
+    mosdepth_regions_bed_csi = "${meta.project.id}_${meta.sample.family_id}_${meta.sample.individual_id}_mosdepth.regions.bed.gz.csi"
+    mosdepth_thresholds_bed = "${meta.project.id}_${meta.sample.family_id}_${meta.sample.individual_id}_mosdepth.thresholds.bed.gz"
+    mosdepth_thresholds_bed_csi= "${meta.project.id}_${meta.sample.family_id}_${meta.sample.individual_id}_mosdepth.thresholds.bed.gz.csi"
 
     paramReference = params[meta.project.assembly].reference.fasta
 
     template 'coverage.sh'
   
   stub:
-    cramCoverageOut="${meta.project.id}_${meta.sample.family_id}_${meta.sample.individual_id}_coverage.tsv.gz"
-		cramDepthOut="${meta.project.id}_${meta.sample.family_id}_${meta.sample.individual_id}_depth.tsv.gz"
+    mosdepth_global = "${meta.project.id}_${meta.sample.family_id}_${meta.sample.individual_id}_mosdepth.global.dist.txt"
+    mosdepth_region = "${meta.project.id}_${meta.sample.family_id}_${meta.sample.individual_id}_mosdepth.region.dist.txt"
+    mosdepth_summary = "${meta.project.id}_${meta.sample.family_id}_${meta.sample.individual_id}_mosdepth.summary.txt"
+    mosdepth_per_base_bed = "${meta.project.id}_${meta.sample.family_id}_${meta.sample.individual_id}_mosdepth.per-base.bed.gz"
+    mosdepth_per_base_bed_csi = "${meta.project.id}_${meta.sample.family_id}_${meta.sample.individual_id}_mosdepth.per-base.bed.gz.csi"
+    mosdepth_regions_bed = "${meta.project.id}_${meta.sample.family_id}_${meta.sample.individual_id}_mosdepth.regions.bed.gz"
+    mosdepth_regions_bed_csi = "${meta.project.id}_${meta.sample.family_id}_${meta.sample.individual_id}_mosdepth.regions.bed.gz.csi"
+    mosdepth_thresholds_bed = "${meta.project.id}_${meta.sample.family_id}_${meta.sample.individual_id}_mosdepth.thresholds.bed.gz"
+    mosdepth_thresholds_bed_csi = "${meta.project.id}_${meta.sample.family_id}_${meta.sample.individual_id}_mosdepth.thresholds.bed.gz.csi"
 
     """
-    touch "${cramCoverageOut}"
-    touch "${cramDepthOut}"
+      touch "${mosdepth_global}"
+      touch "${mosdepth_region}"
+      touch "${mosdepth_summary}"
+      touch "${mosdepth_per_base_bed}"
+      touch "${mosdepth_per_base_bed_csi}"
+      touch "${mosdepth_regions_bed}"
+      touch "${mosdepth_regions_bed_csi}"
+      touch "${mosdepth_thresholds_bed}"
+      touch "${mosdepth_thresholds_bed_csi}"
     """
 }

--- a/modules/cram/templates/coverage.sh
+++ b/modules/cram/templates/coverage.sh
@@ -1,17 +1,29 @@
 #!/bin/bash
 set -euo pipefail
 
-coverage () {
-  ${CMD_SAMTOOLS} coverage --reference "!{paramReference}" "!{cram}" | gzip > "!{cramCoverageOut}"
-}
+mosdepth () {
+    local args=()
+    args+=("--threads"  "!{task.cpus}")
+    args+=("--by" "!{regions}")
+    args+=("--thresholds" "1,5,10,15,20,30,50,100")
+    args+=("--fasta" "!{paramReference}")
+    args+=("mosdepth")
+    args+=("!{cram}")
+    ${CMD_MOSDEPTH} "${args[@]}"
 
-depth () {
-  ${CMD_SAMTOOLS} depth --reference "!{paramReference}" "!{cram}" | gzip > "!{cramDepthOut}"
+    mv "mosdepth.mosdepth.global.dist.txt" "!{mosdepth_global}"
+    mv "mosdepth.mosdepth.region.dist.txt" "!{mosdepth_region}"
+    mv "mosdepth.mosdepth.summary.txt" "!{mosdepth_summary}"
+    mv "mosdepth.per-base.bed.gz" "!{mosdepth_per_base_bed}"
+    mv "mosdepth.per-base.bed.gz.csi" "!{mosdepth_per_base_bed_csi}"
+    mv "mosdepth.regions.bed.gz" "!{mosdepth_regions_bed}"
+    mv "mosdepth.regions.bed.gz.csi" "!{mosdepth_regions_bed_csi}"
+    mv "mosdepth.thresholds.bed.gz" "!{mosdepth_thresholds_bed}"
+    mv "mosdepth.thresholds.bed.gz.csi" "!{mosdepth_thresholds_bed_csi}"
 }
 
 main() {
-  coverage
-  depth
+  mosdepth
 }
 
 main "$@"

--- a/vip_cram.nf
+++ b/vip_cram.nf
@@ -32,7 +32,6 @@ workflow cram {
 
 		// coverage
 		ch_cram_multi.coverage
-      | view
       | filter { meta -> meta.project.regions != null }
 		  | map { meta -> [meta, meta.sample.cram.data, meta.sample.cram.index, meta.project.regions] }
       | coverage

--- a/vip_cram.nf
+++ b/vip_cram.nf
@@ -26,14 +26,16 @@ workflow cram {
     if(params.cram.call_cnv) ++nrActivateVariantCallerTypes;
 
     // output pre-preprocessed crams to coverage, cnv, snv, str and sv channels
-    meta
+    meta    
       | multiMap { it -> coverage: snv: str: sv: cnv: it }
       | set { ch_cram_multi }
 
 		// coverage
 		ch_cram_multi.coverage
-		  | map { meta -> [meta, meta.sample.cram.data, meta.sample.cram.index] }
-		  | coverage
+      | view
+      | filter { meta -> meta.project.regions != null }
+		  | map { meta -> [meta, meta.sample.cram.data, meta.sample.cram.index, meta.project.regions] }
+      | coverage
 
     // snv
     ch_cram_multi.snv
@@ -53,7 +55,7 @@ workflow cram {
       | sv
       | set { ch_cram_sv }
 
-// cnv
+    // cnv
     ch_cram_multi.cnv
       | filter { params.cram.call_cnv == true }
       | cnv


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 
cram/complex                             | PASSED | 288394=completed output/cram/complex/.nxf.log
cram/multiproject                        | PASSED | 288395=completed output/cram/multiproject/.nxf.log
cram/nanopore_duo                        | PASSED | 288396=completed output/cram/nanopore_duo/.nxf.log
cram/nanopore                            | PASSED | 288397=completed output/cram/nanopore/.nxf.log
cram/single                              | PASSED | 288398=completed output/cram/single/.nxf.log
cram/trio                                | PASSED | 288399=completed output/cram/trio/.nxf.log
fastq/nanopore_adaptive_sampling         | PASSED | 287196=completed output/fastq/nanopore_adaptive_sampling/.nxf.log
fastq/nanopore                           | PASSED | 287197=completed output/fastq/nanopore/.nxf.log
fastq/pacbio_hifi                        | PASSED | 287198=completed output/fastq/pacbio_hifi/.nxf.log
gvcf/liftover                            | PASSED | 287199=completed output/gvcf/liftover/.nxf.log
gvcf/multiproject                        | PASSED | 287200=completed output/gvcf/multiproject/.nxf.log
gvcf/trio                                | PASSED | 287201=completed output/gvcf/trio/.nxf.log
vcf/aip                                  | PASSED | 287202=completed output/vcf/aip/.nxf.log
vcf/chd7                                 | PASSED | 287203=completed output/vcf/chd7/.nxf.log
vcf/corner_cases                         | PASSED | 287204=completed output/vcf/corner_cases/.nxf.log
vcf/deb_register                         | PASSED | 287205=completed output/vcf/deb_register/.nxf.log
vcf/empty_input                          | PASSED | 287206=completed output/vcf/empty_input/.nxf.log
vcf/empty_output_filter_samples          | PASSED | 287207=completed output/vcf/empty_output_filter_samples/.nxf.log
vcf/empty_output_filter                  | PASSED | 287208=completed output/vcf/empty_output_filter/.nxf.log
vcf/filter_samples                       | PASSED | 287209=completed output/vcf/filter_samples/.nxf.log
vcf/liftover                             | PASSED | 287210=completed output/vcf/liftover/.nxf.log
vcf/multiproject_classify                | PASSED | 287211=completed output/vcf/multiproject_classify/.nxf.log
vcf/mvid                                 | PASSED | 287212=completed output/vcf/mvid/.nxf.log
vcf/str                                  | PASSED | 287213=completed output/vcf/str/.nxf.log
vcf/trio                                 | PASSED | 287214=completed output/vcf/trio/.nxf.log
vcf/vkgl_lb                              | PASSED | 287215=completed output/vcf/vkgl_lb/.nxf.log
vcf/vkgl_lp                              | PASSED | 287216=completed output/vcf/vkgl_lp/.nxf.log
vcf/vkgl_vus                             | PASSED | 287217=completed output/vcf/vkgl_vus/.nxf.log

