### PR TITLE
Feat/decision tree5

### DIFF
--- a/config/nxf_vcf.config
+++ b/config/nxf_vcf.config
@@ -8,7 +8,7 @@ env {
   CMD_FILTERVEP = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vep-111.0.sif filter_vep"
   CMD_STRANGER = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/stranger-0.8.1_v2.sif stranger"
   CMD_VCFREPORT="apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-report-7.0.3.sif"
-  CMD_VCFDECISIONTREE = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-decision-tree-4.1.4.sif"
+  CMD_VCFDECISIONTREE = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-decision-tree-5.0.0.sif"
   CMD_VCFINHERITANCEMATCHER = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vcf-inheritance-matcher-3.2.1.sif"
 
   // workaround for SAMtools https://github.com/samtools/samtools/issues/1366#issuecomment-769170935

--- a/install.sh
+++ b/install.sh
@@ -87,7 +87,7 @@ download_files() {
   urls+=("4d58cc7a4e3e497a245095a62562e27e" "images/spectre-0.2.1-patched_v2.sif")
   urls+=("8f6e06847776448e004df8b863571109" "images/straglr-1.4.4_vip_v3.sif")
   urls+=("9c69ac645e04b91c8f480289c536429c" "images/stranger-0.8.1_v2.sif")
-  urls+=("" "images/vcf-decision-tree-5.0.0.sif")
+  urls+=("599813c5c0d547c955bd071ccdf220f8" "images/vcf-decision-tree-5.0.0.sif")
   urls+=("f238b75e85e8a097447bad471369d0b2" "images/vcf-inheritance-matcher-3.2.1.sif")
   urls+=("87b2d9031b1b8351d2da14dd0095fbea" "images/vcf-report-7.0.3.sif")
   urls+=("7bffc236a7c65b2b2e2e5f7d64beaa87" "images/vep-111.0.sif")

--- a/install.sh
+++ b/install.sh
@@ -87,7 +87,7 @@ download_files() {
   urls+=("4d58cc7a4e3e497a245095a62562e27e" "images/spectre-0.2.1-patched_v2.sif")
   urls+=("8f6e06847776448e004df8b863571109" "images/straglr-1.4.4_vip_v3.sif")
   urls+=("9c69ac645e04b91c8f480289c536429c" "images/stranger-0.8.1_v2.sif")
-  urls+=("3855ced7eb0c72f283d098d7938d8586" "images/vcf-decision-tree-4.1.4.sif")
+  urls+=("" "images/vcf-decision-tree-5.0.0.sif")
   urls+=("f238b75e85e8a097447bad471369d0b2" "images/vcf-inheritance-matcher-3.2.1.sif")
   urls+=("87b2d9031b1b8351d2da14dd0095fbea" "images/vcf-report-7.0.3.sif")
   urls+=("7bffc236a7c65b2b2e2e5f7d64beaa87" "images/vep-111.0.sif")

--- a/resources/decision_tree_GRCh38.json
+++ b/resources/decision_tree_GRCh38.json
@@ -2,6 +2,7 @@
   "rootNode": "filter",
   "nodes": {
     "filter": {
+      "label": "Filter",
       "description": "Filter pass",
       "type": "BOOL",
       "query": {
@@ -22,6 +23,7 @@
       }
     },
     "vkgl": {
+      "label": "VKGL",
       "description": "VKGL classification",
       "type": "CATEGORICAL",
       "field": "INFO/CSQ/VKGL_CL",
@@ -50,6 +52,7 @@
       }
     },
     "clinVar": {
+      "label": "ClinVar",
       "description": "ClinVar classification",
       "type": "BOOL_MULTI",
       "fields": [
@@ -117,6 +120,7 @@
       }
     },
     "chrom": {
+      "label": "Chromosome",
       "description": "Chromosome 1-22-X-Y-MT",
       "type": "BOOL",
       "query": {
@@ -161,6 +165,7 @@
       }
     },
     "gene": {
+      "label": "Gene",
       "description": "Gene exists",
       "type": "EXISTS",
       "field": "INFO/CSQ/Gene",
@@ -172,6 +177,7 @@
       }
     },
     "sv": {
+      "label": "Is SV",
       "description": "Structural Variant?",
       "type": "EXISTS",
       "field": "INFO/SVTYPE",
@@ -183,6 +189,7 @@
       }
     },
     "str": {
+      "label": "Is STR",
       "description": "Short tandem repeat?",
       "type": "BOOL",
       "query": {
@@ -201,6 +208,7 @@
       }
     },
     "str_status": {
+      "label": "STR Status",
       "description": "Stranger str status (normal, pre_mutation, mutation)",
       "type": "CATEGORICAL",
       "field": "INFO/STR_STATUS",
@@ -223,6 +231,7 @@
       }
     },
     "gnomAD": {
+      "label": "GnomAD",
       "description": "gnomAD QC filter failure",
       "type": "EXISTS",
       "field": "INFO/CSQ/gnomAD_QC",
@@ -234,6 +243,7 @@
       }
     },
     "gnomAD_AF": {
+      "label": "GnomAD AF",
       "description": "gnomAD",
       "type": "BOOL_MULTI",
       "fields": [
@@ -269,6 +279,7 @@
       }
     },
     "annotSV": {
+      "label": "AnnotSV",
       "description": "AnnotSV classification",
       "type": "CATEGORICAL",
       "field": "INFO/CSQ/ASV_ACMG_class",
@@ -297,6 +308,7 @@
       }
     },
     "spliceAI": {
+      "label": "SpliceAI",
       "description": "SpliceAI prediction",
       "type": "BOOL_MULTI",
       "fields": [
@@ -373,6 +385,7 @@
       }
     },
     "utr5": {
+      "label": "5' UTR",
       "description": "5' UTR",
       "type": "EXISTS",
       "field": "INFO/CSQ/five_prime_UTR_variant_consequence",
@@ -384,6 +397,7 @@
       }
     },
     "capice": {
+      "label": "CAPICE",
       "description": "CAPICE prediction > 0.5",
       "type": "BOOL",
       "query": {
@@ -402,31 +416,37 @@
       }
     },
     "exit_rm": {
+      "label": "Remove",
       "description": "Remove",
       "type": "LEAF",
       "class": "LQ"
     },
     "exit_b": {
+      "label": "Benign",
       "description": "Benign",
       "type": "LEAF",
       "class": "B"
     },
     "exit_lb": {
+      "label": "Likely Benign",
       "description": "Likely Benign",
       "type": "LEAF",
       "class": "LB"
     },
     "exit_vus": {
+      "label": "Uncertain Significance",
       "description": "Uncertain Significance",
       "type": "LEAF",
       "class": "VUS"
     },
     "exit_lp": {
+      "label": "Likely Pathogenic",
       "description": "Likely Pathogenic",
       "type": "LEAF",
       "class": "LP"
     },
     "exit_p": {
+      "label": "Pathogenic",
       "description": "Pathogenic",
       "type": "LEAF",
       "class": "P"

--- a/resources/decision_tree_samples.json
+++ b/resources/decision_tree_samples.json
@@ -2,6 +2,7 @@
   "rootNode": "gt",
   "nodes": {
     "gt": {
+      "label": "Genotype",
       "description": "Genotype",
       "type": "CATEGORICAL",
       "field": "FORMAT/GENOTYPE/TYPE",
@@ -34,6 +35,7 @@
     },
     "gq": {
       "type": "BOOL",
+      "label": "Genotype quality",
       "description": "Genotype quality",
       "query": {
         "field": "FORMAT/GQ",
@@ -52,6 +54,7 @@
     },
     "only_IP": {
       "type": "BOOL",
+      "label": "Only if AD IP",
       "description": "Only AD IP suitable for pedigree.",
       "query": {
         "field": "FORMAT/VI",
@@ -70,6 +73,7 @@
     },
     "vim": {
       "type": "BOOL",
+      "label": "Inheritance match",
       "description": "Inheritance match",
       "query": {
         "field": "FORMAT/VIG",
@@ -88,6 +92,7 @@
     },
     "vim_IP": {
       "type": "BOOL",
+      "label": "Inheritance match (IP)",
       "description": "Inheritance match",
       "query": {
         "field": "FORMAT/VIG",
@@ -106,6 +111,7 @@
     },
     "vid": {
       "type": "BOOL",
+      "label": "Inheritance denovo",
       "description": "Inheritance denovo",
       "query": {
         "field": "FORMAT/VID",
@@ -124,6 +130,7 @@
     },
     "vid_IP": {
       "type": "BOOL",
+      "label": "Inheritance denovo (IP)",
       "description": "Inheritance denovo",
       "query": {
         "field": "FORMAT/VID",
@@ -141,21 +148,25 @@
       }
     },
     "exit_u1": {
+      "label": "Usable: probably",
       "description": "Usable: probably",
       "type": "LEAF",
       "class": "U1"
     },
     "exit_u2": {
+      "label": "Usable: maybe",
       "description": "Usable: maybe",
       "type": "LEAF",
       "class": "U2"
     },
     "exit_u3": {
+      "label": "Usable: probably not",
       "description": "Usable: probably not",
       "type": "LEAF",
       "class": "U3"
     },
     "exit_u4": {
+      "label": "Usable: if IP",
       "description": "Usable: in case of incomplete penetrance",
       "type": "LEAF",
       "class": "U4"

--- a/utils/apptainer/build.sh
+++ b/utils/apptainer/build.sh
@@ -96,7 +96,7 @@ main() {
   images+=("spectre-0.2.1-patched_v2")
   images+=("stranger-0.8.1_v2")
   images+=("straglr-1.4.4_vip_v3")
-  images+=("vcf-decision-tree-4.1.4")
+  images+=("vcf-decision-tree-5.0.0")
   images+=("vcf-inheritance-matcher-3.2.1")
   images+=("vcf-report-7.0.3")
 

--- a/utils/apptainer/def/vcf-decision-tree-5.0.0.def
+++ b/utils/apptainer/def/vcf-decision-tree-5.0.0.def
@@ -6,9 +6,9 @@ From: sif/build/openjdk-21.sif
     Usage: java -jar /opt/vcf-decision-tree/lib/vcf-decision-tree.jar
 
 %post
-    version_major=4
-    version_minor=1
-    version_patch=4
+    version_major=5
+    version_minor=0
+    version_patch=0
 
     # install
     apk update
@@ -16,7 +16,7 @@ From: sif/build/openjdk-21.sif
 
     mkdir -p /opt/vcf-decision-tree/lib
     curl -Ls -o /opt/vcf-decision-tree/lib/vcf-decision-tree.jar "https://github.com/molgenis/vip-decision-tree/releases/download/v${version_major}.${version_minor}.${version_patch}/vcf-decision-tree.jar"
-    echo "da4f0ae7a45e5923a6202c990a24f6331a492efa973fb3b590e14384f3fc0adb  /opt/vcf-decision-tree/lib/vcf-decision-tree.jar" | sha256sum -c
+    echo "5c40990aa4f300627e3bed261b2173361db165aea4c5b4aa84012df6277f95be  /opt/vcf-decision-tree/lib/vcf-decision-tree.jar" | sha256sum -c
 
     # cleanup
     apk del .build-dependencies


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 
vcf/aip                                  | PASSED | 290785=completed output/vcf/aip/.nxf.log
vcf/chd7                                 | PASSED | 290786=completed output/vcf/chd7/.nxf.log
vcf/corner_cases                         | PASSED | 290787=completed output/vcf/corner_cases/.nxf.log
vcf/deb_register                         | PASSED | 290788=completed output/vcf/deb_register/.nxf.log
vcf/empty_input                          | PASSED | 290789=completed output/vcf/empty_input/.nxf.log
vcf/empty_output_filter_samples          | PASSED | 290790=completed output/vcf/empty_output_filter_samples/.nxf.log
vcf/empty_output_filter                  | PASSED | 290791=completed output/vcf/empty_output_filter/.nxf.log
vcf/filter_samples                       | PASSED | 290792=completed output/vcf/filter_samples/.nxf.log
vcf/liftover                             | PASSED | 290793=completed output/vcf/liftover/.nxf.log
vcf/multiproject_classify                | PASSED | 290794=completed output/vcf/multiproject_classify/.nxf.log
vcf/mvid                                 | PASSED | 290795=completed output/vcf/mvid/.nxf.log
vcf/str                                  | PASSED | 290796=completed output/vcf/str/.nxf.log
vcf/trio                                 | PASSED | 290797=completed output/vcf/trio/.nxf.log
vcf/vkgl_lb                              | PASSED | 290798=completed output/vcf/vkgl_lb/.nxf.log
vcf/vkgl_lp                              | PASSED | 290799=completed output/vcf/vkgl_lp/.nxf.log
vcf/vkgl_vus                             | PASSED | 290800=completed output/vcf/vkgl_vus/.nxf.log
