### PR TITLE
feat:sample sheet HPO validation

### DIFF
--- a/config/nxf.config
+++ b/config/nxf.config
@@ -39,7 +39,9 @@ profiles {
 params {
   // output assembly
   assembly = "GRCh38"
-  
+  // created using HpoMapperApp.java in https://github.com/molgenis/vip-utils
+  hpo_phenotypic_abnormality="${projectDir}/resources/hpo_20240404_phenotypic_abnormality.tsv"
+
   GRCh37 {
     reference {
       fasta = "${projectDir}/resources/GRCh37/human_g1k_v37.fasta.gz"

--- a/install.sh
+++ b/install.sh
@@ -143,6 +143,7 @@ download_files() {
   urls+=("5d4d1c938ff58dbf2d2799a5e4dd06c4" "resources/gado/v1.0.4_HPO_v2024-04-04/HPO_2024_04_04_prediction_info.txt.gz")
   # update utils/install.sh when updating hpo.tsv
   urls+=("42e31fe6e3502fb9bc0b14121f0f844b" "resources/hpo_20240404.tsv")
+  urls+=("4df3215561db69196b6918f501810880" "resources/hpo_20240404_phenotypic_abnormality.tsv")
   # update utils/install.sh when updating inheritance.tsv
   urls+=("df31eb0fe9ebd9ae26c8d6f5f7ba6e57" "resources/inheritance_20240115.tsv")
   urls+=("7138e76a38d6f67935699d06082ecacf" "resources/vep/cache/homo_sapiens_refseq_vep_111_GRCh38.tar.gz")

--- a/install.sh
+++ b/install.sh
@@ -143,7 +143,7 @@ download_files() {
   urls+=("5d4d1c938ff58dbf2d2799a5e4dd06c4" "resources/gado/v1.0.4_HPO_v2024-04-04/HPO_2024_04_04_prediction_info.txt.gz")
   # update utils/install.sh when updating hpo.tsv
   urls+=("42e31fe6e3502fb9bc0b14121f0f844b" "resources/hpo_20240404.tsv")
-  urls+=("4df3215561db69196b6918f501810880" "resources/hpo_20240404_phenotypic_abnormality.tsv")
+  urls+=("c2efd2d7f37ca5e20cdfc908cc28475b" "resources/hpo_20240404_phenotypic_abnormality.tsv")
   # update utils/install.sh when updating inheritance.tsv
   urls+=("df31eb0fe9ebd9ae26c8d6f5f7ba6e57" "resources/inheritance_20240115.tsv")
   urls+=("7138e76a38d6f67935699d06082ecacf" "resources/vep/cache/homo_sapiens_refseq_vep_111_GRCh38.tar.gz")

--- a/modules/sample_sheet.nf
+++ b/modules/sample_sheet.nf
@@ -4,17 +4,6 @@ def parseHpoPhenotypicAbnormality(hpoPhenotypicAbnormalityFilename) {
   def lines = hpoFile.readLines("UTF-8")
 	if (lines.size() == 0) exit 1, "error parsing '${hpoPhenotypicAbnormalityFilename}': file is empty"
 
-	def headerTokens = lines[0].split('\t', -1)
-	def colsWithIndex
-	try {
-		colsWithIndex = parseHeader(headerTokens, cols)
-	} catch(IllegalArgumentException e) {
-		exit 1, "error parsing '${hpoPhenotypicAbnormalityFilename}' line 1: ${e.message}"
-	}
-
-	def col=colsWithIndex["id"]
-	if(col == null) exit 1, "error parsing '${hpoPhenotypicAbnormalityFilename}' line 1: missing column 'id'"
-
 	def hpoTermIds=[:]
 	for (int i = 1; i < lines.size(); i++) {
 		def lineNr = i + 1
@@ -25,7 +14,7 @@ def parseHpoPhenotypicAbnormality(hpoPhenotypicAbnormalityFilename) {
 		def tokens = line.split('\t', -1)
 		if (tokens.length != headerTokens.length) exit 1, "error parsing '${csvFilename}' line ${lineNr}: expected ${headerTokens.length} columns instead of ${tokens.length}"
 
-		def hpoTermId=tokens[col.index]
+		def hpoTermId=tokens[0]
 		hpoTermIds[hpoTermId]=null
 	}
 	return hpoTermIds

--- a/modules/sample_sheet.nf
+++ b/modules/sample_sheet.nf
@@ -1,4 +1,37 @@
-def parseCommonSampleSheet(csvFilename, additionalCols) {
+def parseHpoPhenotypicAbnormality(hpoPhenotypicAbnormalityFilename) {
+  def hpoFile = new File(hpoPhenotypicAbnormalityFilename)
+
+  def lines = hpoFile.readLines("UTF-8")
+	if (lines.size() == 0) exit 1, "error parsing '${hpoPhenotypicAbnormalityFilename}': file is empty"
+
+	def headerTokens = lines[0].split('\t', -1)
+	def colsWithIndex
+	try {
+		colsWithIndex = parseHeader(headerTokens, cols)
+	} catch(IllegalArgumentException e) {
+		exit 1, "error parsing '${hpoPhenotypicAbnormalityFilename}' line 1: ${e.message}"
+	}
+
+	def col=colsWithIndex["id"]
+	if(col == null) exit 1, "error parsing '${hpoPhenotypicAbnormalityFilename}' line 1: missing column 'id'"
+
+	def hpoTermIds=[:]
+	for (int i = 1; i < lines.size(); i++) {
+		def lineNr = i + 1
+
+		def line = lines[i]
+		if (line == null) continue;
+
+		def tokens = line.split('\t', -1)
+		if (tokens.length != headerTokens.length) exit 1, "error parsing '${csvFilename}' line ${lineNr}: expected ${headerTokens.length} columns instead of ${tokens.length}"
+
+		def hpoTermId=tokens[col.index]
+		hpoTermIds[hpoTermId]=null
+	}
+	return hpoTermIds
+}
+
+def parseCommonSampleSheet(csvFilename, hpoPhenotypicAbnormalityFilename, additionalCols) {
   def csvFile = new File(csvFilename)
 
   def seq_nr = 0
@@ -61,7 +94,9 @@ def parseCommonSampleSheet(csvFilename, additionalCols) {
   ]
 
   def cols = [*:commonCols, *:additionalCols]
-    
+
+  def hpoTermIdMap = parseHpoPhenotypicAbnormality(hpoPhenotypicAbnormalityFilename)
+
   def lines = csvFile.readLines("UTF-8")
   if (lines.size() == 0) exit 1, "error parsing '${csvFilename}': file is empty"
   
@@ -87,7 +122,7 @@ def parseCommonSampleSheet(csvFilename, additionalCols) {
     
     def sample
     try {
-      sample = parseSample(tokens, colsWithIndex, csvFile.getParentFile())
+      sample = parseSample(tokens, colsWithIndex, csvFile.getParentFile(), hpoTermIdMap)
     } catch(IllegalArgumentException e) {
       exit 1, "error parsing '${csvFilename}' line ${lineNr}: ${e.message}"
     }
@@ -225,12 +260,21 @@ def parseValue(token, col, rootDir) {
   return value;
 }
 
-def parseSample(tokens, cols, rootDir) {
+def parseSample(tokens, cols, rootDir, hpoTermIdMap) {
     def sample = [:]
     cols.each { colId, col -> 
       def token = col.index != null ? tokens[col.index] : ''
       try {
-        sample[colId] = parseValue(token, col, rootDir)
+        def value = parseValue(token, col, rootDir)
+        if(col.name == "hpo_ids") {
+        	value.each { hpoTermId ->
+        	  if(!hpoTermIdMap.containsKey(hpoTermId)) {
+        	    throw new IllegalArgumentException("HPO term '${hpoTermId}' is not a child of 'HP:0000118' (phenotypic abnormality)")
+        	  }
+        	}
+        }
+
+        sample[colId] = value
       } catch(IllegalArgumentException e) {
         throw new IllegalArgumentException("column '${colId}': ${e.message}")
       }

--- a/modules/sample_sheet.nf
+++ b/modules/sample_sheet.nf
@@ -12,7 +12,7 @@ def parseHpoPhenotypicAbnormality(hpoPhenotypicAbnormalityFilename) {
 		if (line == null) continue;
 
 		def tokens = line.split('\t', -1)
-		if (tokens.length != 2) exit 1, "error parsing '${csvFilename}' line ${lineNr}: expected 2 columns instead of ${tokens.length}"
+		if (tokens.length != 2) exit 1, "error parsing '${hpoPhenotypicAbnormalityFilename}' line ${lineNr}: expected 2 columns instead of ${tokens.length}"
 
 		def hpoTermId=tokens[0]
 		hpoTermIds[hpoTermId]=null

--- a/modules/sample_sheet.nf
+++ b/modules/sample_sheet.nf
@@ -4,7 +4,7 @@ def parseHpoPhenotypicAbnormality(hpoPhenotypicAbnormalityFilename) {
   def lines = hpoFile.readLines("UTF-8")
 	if (lines.size() == 0) exit 1, "error parsing '${hpoPhenotypicAbnormalityFilename}': file is empty"
 
-	if (lines[0] != "id\label\description") {
+	if (lines[0] != "id\tlabel\tdescription") {
 	  exit 1, "error parsing '${hpoPhenotypicAbnormalityFilename}': file header invalid, expected 'id<tab>label<description>'"
 	}
 

--- a/modules/sample_sheet.nf
+++ b/modules/sample_sheet.nf
@@ -4,6 +4,10 @@ def parseHpoPhenotypicAbnormality(hpoPhenotypicAbnormalityFilename) {
   def lines = hpoFile.readLines("UTF-8")
 	if (lines.size() == 0) exit 1, "error parsing '${hpoPhenotypicAbnormalityFilename}': file is empty"
 
+	if (lines[0] != "id\label\description") {
+	  exit 1, "error parsing '${hpoPhenotypicAbnormalityFilename}': file header invalid, expected 'id<tab>label<description>'"
+	}
+
 	def hpoTermIds=[:]
 	for (int i = 1; i < lines.size(); i++) {
 		def lineNr = i + 1
@@ -12,7 +16,7 @@ def parseHpoPhenotypicAbnormality(hpoPhenotypicAbnormalityFilename) {
 		if (line == null) continue;
 
 		def tokens = line.split('\t', -1)
-		if (tokens.length != 2) exit 1, "error parsing '${hpoPhenotypicAbnormalityFilename}' line ${lineNr}: expected 2 columns instead of ${tokens.length}"
+		if (tokens.length != 2) exit 1, "error parsing '${hpoPhenotypicAbnormalityFilename}' line ${lineNr}: expected 3 columns instead of ${tokens.length}"
 
 		def hpoTermId=tokens[0]
 		hpoTermIds[hpoTermId]=null

--- a/modules/sample_sheet.nf
+++ b/modules/sample_sheet.nf
@@ -259,7 +259,7 @@ def parseSample(tokens, cols, rootDir, hpoTermIdMap) {
       def token = col.index != null ? tokens[col.index] : ''
       try {
         def value = parseValue(token, col, rootDir)
-        if(col.name == "hpo_ids") {
+        if(colId == "hpo_ids") {
         	value.each { hpoTermId ->
         	  if(!hpoTermIdMap.containsKey(hpoTermId)) {
         	    throw new IllegalArgumentException("HPO term '${hpoTermId}' is not a child of 'HP:0000118' (phenotypic abnormality)")

--- a/modules/sample_sheet.nf
+++ b/modules/sample_sheet.nf
@@ -12,7 +12,7 @@ def parseHpoPhenotypicAbnormality(hpoPhenotypicAbnormalityFilename) {
 		if (line == null) continue;
 
 		def tokens = line.split('\t', -1)
-		if (tokens.length != headerTokens.length) exit 1, "error parsing '${csvFilename}' line ${lineNr}: expected ${headerTokens.length} columns instead of ${tokens.length}"
+		if (tokens.length != 2) exit 1, "error parsing '${csvFilename}' line ${lineNr}: expected 2 columns instead of ${tokens.length}"
 
 		def hpoTermId=tokens[0]
 		hpoTermIds[hpoTermId]=null

--- a/modules/sample_sheet.nf
+++ b/modules/sample_sheet.nf
@@ -16,7 +16,7 @@ def parseHpoPhenotypicAbnormality(hpoPhenotypicAbnormalityFilename) {
 		if (line == null) continue;
 
 		def tokens = line.split('\t', -1)
-		if (tokens.length != 2) exit 1, "error parsing '${hpoPhenotypicAbnormalityFilename}' line ${lineNr}: expected 3 columns instead of ${tokens.length}"
+		if (tokens.length != 3) exit 1, "error parsing '${hpoPhenotypicAbnormalityFilename}' line ${lineNr}: expected 3 columns instead of ${tokens.length}"
 
 		def hpoTermId=tokens[0]
 		hpoTermIds[hpoTermId]=null

--- a/test/suites/cram/resources/multiproject.tsv
+++ b/test/suites/cram/resources/multiproject.tsv
@@ -1,3 +1,3 @@
 project_id	family_id	proband	individual_id	hpo_ids	sequencing_platform	cram	sequencing_method
-vip1	fam0	true	NA12878	HP:0000001,HP:0000002	illumina	downloads/multiproject_vip1.cram	WES
-vip2	fam1	true	NA12878	HP:0000001	illumina	downloads/multiproject_vip2.bam	WES
+vip1	fam0	true	NA12878	HP:0001626,HP:0000707	illumina	downloads/multiproject_vip1.cram	WES
+vip2	fam1	true	NA12878	HP:0001626	illumina	downloads/multiproject_vip2.bam	WES

--- a/test/suites/cram/resources/single.tsv
+++ b/test/suites/cram/resources/single.tsv
@@ -1,2 +1,2 @@
 family_id	proband	individual_id	hpo_ids	sequencing_platform	cram	sequencing_method	regions
-fam0	true	NA12878	HP:0000001,HP:0000002	illumina	downloads/single.cram	WES	single.bed
+fam0	true	NA12878	HP:0001626,HP:0000707	illumina	downloads/single.cram	WES	single.bed

--- a/test/suites/cram/resources/trio.tsv
+++ b/test/suites/cram/resources/trio.tsv
@@ -1,4 +1,4 @@
 family_id	proband	individual_id	paternal_id	maternal_id	hpo_ids	sequencing_platform	cram	sequencing_method
-fam0	true	patient	father	mother	HP:0000001,HP:0000002	illumina	downloads/trio_patient.bam	WES
-fam0	false	father			HP:0000001,HP:0000002	illumina	downloads/trio_father.cram	WES
-fam0	false	mother			HP:0000001,HP:0000002	illumina	downloads/trio_mother.cram	WES
+fam0	true	patient	father	mother	HP:0001626,HP:0000707	illumina	downloads/trio_patient.bam	WES
+fam0	false	father			HP:0001626,HP:0000707	illumina	downloads/trio_father.cram	WES
+fam0	false	mother			HP:0001626,HP:0000707	illumina	downloads/trio_mother.cram	WES

--- a/utils/install.sh
+++ b/utils/install.sh
@@ -65,6 +65,9 @@ install() {
   if [ -f "${SCRIPT_DIR}/resources/hpo_20240404.tsv" ]; then
     cp --link "${SCRIPT_DIR}/resources/hpo_20240404.tsv" "${versionDir}/resources"
   fi
+  if [ -f "${SCRIPT_DIR}/resources/hpo_20240404_phenotypic_abnormality.tsv" ]; then
+      cp --link "${SCRIPT_DIR}/resources/hpo_20240404_phenotypic_abnormality.tsv" "${versionDir}/resources"
+    fi
   if [ -f "${SCRIPT_DIR}/resources/inheritance_20240115.tsv" ]; then
     cp --link "${SCRIPT_DIR}/resources/inheritance_20240115.tsv" "${versionDir}/resources"
   fi
@@ -82,6 +85,9 @@ install() {
   if [ -f "${versionDir}/resources/hpo_20240404.tsv" ] && [ ! -f "${SCRIPT_DIR}/resources/hpo_20240404.tsv" ]; then
     cp --link "${versionDir}/resources/hpo_20240404.tsv" "${SCRIPT_DIR}/resources"
   fi
+  if [ -f "${versionDir}/resources/hpo_20240404_phenotypic_abnormality.tsv" ] && [ ! -f "${SCRIPT_DIR}/resources/hpo_20240404_phenotypic_abnormality.tsv" ]; then
+      cp --link "${versionDir}/resources/hpo_20240404_phenotypic_abnormality.tsv" "${SCRIPT_DIR}/resources"
+    fi
   if [ -f "${versionDir}/resources/inheritance_20240115.tsv" ] && [ ! -f "${SCRIPT_DIR}/resources/inheritance_20240115.tsv" ]; then
     cp --link "${versionDir}/resources/inheritance_20240115.tsv" "${SCRIPT_DIR}/resources"
   fi

--- a/vip_cram.nf
+++ b/vip_cram.nf
@@ -103,7 +103,7 @@ workflow cram {
 }
 
 workflow {
-  def projects = parseSampleSheet(params.input)
+  def projects = parseSampleSheet(params)
   def assemblies = getAssemblies(projects)
   validateCramParams(assemblies)
 
@@ -157,7 +157,7 @@ def validateCramParams(inputAssemblies) {
   if(callCnv) validateCallCnvParams(outputAssemblies)
 }
 
-def parseSampleSheet(csvFile) {
+def parseSampleSheet(params) {
   def cols = [
     cram: [
       type: "file",
@@ -172,6 +172,6 @@ def parseSampleSheet(csvFile) {
     ]
   ]
 
-  def projects = parseCommonSampleSheet(csvFile, cols)
+	def projects = parseCommonSampleSheet(params.input, params.hpo_phenotypic_abnormality, cols)
   return projects.collect { project -> [*:project, assembly: params.assembly] }
 }

--- a/vip_fastq.nf
+++ b/vip_fastq.nf
@@ -60,7 +60,7 @@ workflow fastq {
 }
 
 workflow {
-  def projects = parseSampleSheet(params.input)
+  def projects = parseSampleSheet(params)
   validateFastqParams([params.assembly])
 
   // run fastq workflow for each sample in each project
@@ -81,7 +81,7 @@ def validateFastqParams(assemblies) {
   }  
 }
 
-def parseSampleSheet(csvFile) {
+def parseSampleSheet(params) {
   def fastqRegex = /.+\.(fastq|fq)(\.gz)?/
   
   def cols = [
@@ -112,7 +112,7 @@ def parseSampleSheet(csvFile) {
     ]
   ]
 
-  def projects = parseCommonSampleSheet(csvFile, cols)
+	def projects = parseCommonSampleSheet(params.input, params.hpo_phenotypic_abnormality, cols)
   validate(projects)
   return projects
 }

--- a/vip_gvcf.nf
+++ b/vip_gvcf.nf
@@ -35,7 +35,7 @@ workflow gvcf {
 }
 
 workflow {
-  def projects = parseSampleSheet(params.input)
+  def projects = parseSampleSheet(params)
   def assemblies = getAssemblies(projects)
   validateGenomeVcfParams(assemblies)
 
@@ -103,7 +103,7 @@ def validateGenomeVcfParams(assemblies) {
   if (!(mergePreset ==~ /gatk|gatk_unfiltered|DeepVariant|DeepVariant_unfiltered/))  exit 1, "parameter 'gvcf.merge_preset' value '${mergePreset}' is invalid. allowed values are [gatk, gatk_unfiltered, DeepVariant, DeepVariant_unfiltered]"
 }
 
-def parseSampleSheet(csvFile) {
+def parseSampleSheet(params) {
   def cols = [
 		assembly: [
 			type: "string",
@@ -120,8 +120,8 @@ def parseSampleSheet(csvFile) {
       regex: getCramRegex()
     ]
   ]
-  
-  def projects = parseCommonSampleSheet(csvFile, cols)
+
+	def projects = parseCommonSampleSheet(params.input, params.hpo_phenotypic_abnormality, cols)
   validate(projects)
   return projects
 }

--- a/vip_vcf.nf
+++ b/vip_vcf.nf
@@ -232,7 +232,7 @@ workflow vcf {
 }
 
 workflow {
-  def projects = parseSampleSheet(params.input)
+  def projects = parseSampleSheet(params)
   def assemblies = getAssemblies(projects)
   validateVcfParams(assemblies)
 
@@ -393,7 +393,7 @@ def validateVcfParams(inputAssemblies) {
   }
 }
 
-def parseSampleSheet(csvFile) {
+def parseSampleSheet(params) {
   def cols = [
   	assembly: [
 			type: "string",
@@ -413,7 +413,7 @@ def parseSampleSheet(csvFile) {
     ]
   ]
 
-  def projects = parseCommonSampleSheet(csvFile, cols)
+  def projects = parseCommonSampleSheet(params.input, params.hpo_phenotypic_abnormality, cols)
   validate(projects)
   return projects
 }


### PR DESCRIPTION
```
running tests ...
cram/complex                             | PASSED | 293890=completed test/output/cram/complex/.nxf.log
cram/multiproject                        | PASSED | 293891=completed test/output/cram/multiproject/.nxf.log
cram/nanopore_duo                        | PASSED | 293892=completed test/output/cram/nanopore_duo/.nxf.log
cram/nanopore                            | PASSED | 293893=completed test/output/cram/nanopore/.nxf.log
cram/single                              | PASSED | 293894=completed test/output/cram/single/.nxf.log
cram/trio                                | PASSED | 293895=completed test/output/cram/trio/.nxf.log
fastq/nanopore_adaptive_sampling         | PASSED | 293896=completed test/output/fastq/nanopore_adaptive_sampling/.nxf.log
fastq/nanopore                           | PASSED | 293897=completed test/output/fastq/nanopore/.nxf.log
fastq/pacbio_hifi                        | PASSED | 293898=completed test/output/fastq/pacbio_hifi/.nxf.log
gvcf/liftover                            | PASSED | 293899=completed test/output/gvcf/liftover/.nxf.log
gvcf/multiproject                        | PASSED | 293900=completed test/output/gvcf/multiproject/.nxf.log
gvcf/trio                                | PASSED | 293901=completed test/output/gvcf/trio/.nxf.log
vcf/aip                                  | PASSED | 293902=completed test/output/vcf/aip/.nxf.log
vcf/chd7                                 | PASSED | 293903=completed test/output/vcf/chd7/.nxf.log
vcf/corner_cases                         | PASSED | 293904=completed test/output/vcf/corner_cases/.nxf.log
vcf/deb_register                         | PASSED | 293905=completed test/output/vcf/deb_register/.nxf.log
vcf/empty_input                          | PASSED | 293906=completed test/output/vcf/empty_input/.nxf.log
vcf/empty_output_filter_samples          | PASSED | 293907=completed test/output/vcf/empty_output_filter_samples/.nxf.log
vcf/empty_output_filter                  | PASSED | 293908=completed test/output/vcf/empty_output_filter/.nxf.log
vcf/filter_samples                       | PASSED | 293909=completed test/output/vcf/filter_samples/.nxf.log
vcf/liftover                             | PASSED | 293910=completed test/output/vcf/liftover/.nxf.log
vcf/multiproject_classify                | PASSED | 293911=completed test/output/vcf/multiproject_classify/.nxf.log
vcf/mvid                                 | PASSED | 293912=completed test/output/vcf/mvid/.nxf.log
vcf/str                                  | PASSED | 293913=completed test/output/vcf/str/.nxf.log
vcf/trio                                 | PASSED | 293914=completed test/output/vcf/trio/.nxf.log
vcf/vkgl_lb                              | PASSED | 293915=completed test/output/vcf/vkgl_lb/.nxf.log
vcf/vkgl_lp                              | PASSED | 293916=completed test/output/vcf/vkgl_lp/.nxf.log
vcf/vkgl_vus                             | PASSED | 293917=completed test/output/vcf/vkgl_vus/.nxf.log
done
```