### PR TITLE
fix:bump vip-report-template v7.0.2 to v7.0.5

### DIFF
--- a/config/nxf_vcf.config
+++ b/config/nxf_vcf.config
@@ -111,7 +111,7 @@ params {
       include_crams = true
       max_records = ""
       max_samples = ""
-      template = "${projectDir}/resources/vip-report-template-v7.0.4.html"
+      template = "${projectDir}/resources/vip-report-template-v7.0.5.html"
       config = "${projectDir}/resources/vcf_report_config.json"
 			metadata = "${projectDir}/resources/field_metadata.json"
 

--- a/config/nxf_vcf.config
+++ b/config/nxf_vcf.config
@@ -111,7 +111,7 @@ params {
       include_crams = true
       max_records = ""
       max_samples = ""
-      template = "${projectDir}/resources/vip-report-template-v7.0.2.html"
+      template = "${projectDir}/resources/vip-report-template-v7.0.3.html"
       config = "${projectDir}/resources/vcf_report_config.json"
 			metadata = "${projectDir}/resources/field_metadata.json"
 

--- a/config/nxf_vcf.config
+++ b/config/nxf_vcf.config
@@ -111,7 +111,7 @@ params {
       include_crams = true
       max_records = ""
       max_samples = ""
-      template = "${projectDir}/resources/vip-report-template-v7.0.3.html"
+      template = "${projectDir}/resources/vip-report-template-v7.0.4.html"
       config = "${projectDir}/resources/vcf_report_config.json"
 			metadata = "${projectDir}/resources/field_metadata.json"
 

--- a/install.sh
+++ b/install.sh
@@ -147,7 +147,7 @@ download_files() {
   # update utils/install.sh when updating inheritance.tsv
   urls+=("df31eb0fe9ebd9ae26c8d6f5f7ba6e57" "resources/inheritance_20240115.tsv")
   urls+=("7138e76a38d6f67935699d06082ecacf" "resources/vep/cache/homo_sapiens_refseq_vep_111_GRCh38.tar.gz")
-  urls+=("e5d17440fc84b49b2fba7a30b500ca93" "resources/vip-report-template-v7.0.2.html")
+  urls+=("d8b9cd7effa2ca6a99f63b66f4defc65" "resources/vip-report-template-v7.0.3.html")
   # when modifying urls array, please keep list in 'ls -l' order
   for ((i = 0; i < ${#urls[@]}; i += 2)); do
     download_file "${base_url}" "${urls[i+1]}" "${urls[i+0]}" "${output_dir}" "${validate}"

--- a/install.sh
+++ b/install.sh
@@ -147,7 +147,7 @@ download_files() {
   # update utils/install.sh when updating inheritance.tsv
   urls+=("df31eb0fe9ebd9ae26c8d6f5f7ba6e57" "resources/inheritance_20240115.tsv")
   urls+=("7138e76a38d6f67935699d06082ecacf" "resources/vep/cache/homo_sapiens_refseq_vep_111_GRCh38.tar.gz")
-  urls+=("d8b9cd7effa2ca6a99f63b66f4defc65" "resources/vip-report-template-v7.0.3.html")
+  urls+=("164105239d6ef6228807c11bdec51a0a" "resources/vip-report-template-v7.0.4.html")
   # when modifying urls array, please keep list in 'ls -l' order
   for ((i = 0; i < ${#urls[@]}; i += 2)); do
     download_file "${base_url}" "${urls[i+1]}" "${urls[i+0]}" "${output_dir}" "${validate}"

--- a/install.sh
+++ b/install.sh
@@ -147,7 +147,7 @@ download_files() {
   # update utils/install.sh when updating inheritance.tsv
   urls+=("df31eb0fe9ebd9ae26c8d6f5f7ba6e57" "resources/inheritance_20240115.tsv")
   urls+=("7138e76a38d6f67935699d06082ecacf" "resources/vep/cache/homo_sapiens_refseq_vep_111_GRCh38.tar.gz")
-  urls+=("164105239d6ef6228807c11bdec51a0a" "resources/vip-report-template-v7.0.4.html")
+  urls+=("6949ed9cbbdfdc4c7744ea4a6756687d" "resources/vip-report-template-v7.0.5.html")
   # when modifying urls array, please keep list in 'ls -l' order
   for ((i = 0; i < ${#urls[@]}; i += 2)); do
     download_file "${base_url}" "${urls[i+1]}" "${urls[i+0]}" "${output_dir}" "${validate}"


### PR DESCRIPTION
```
running tests ...
cram/complex                             | PASSED | 300662=completed test/output/cram/complex/.nxf.log
cram/multiproject                        | PASSED | 300663=completed test/output/cram/multiproject/.nxf.log
cram/nanopore_duo                        | PASSED | 300664=completed test/output/cram/nanopore_duo/.nxf.log
cram/nanopore                            | PASSED | 300665=completed test/output/cram/nanopore/.nxf.log
cram/single                              | PASSED | 300666=completed test/output/cram/single/.nxf.log
cram/trio                                | PASSED | 300667=completed test/output/cram/trio/.nxf.log
fastq/nanopore_adaptive_sampling         | PASSED | 300668=completed test/output/fastq/nanopore_adaptive_sampling/.nxf.log
fastq/nanopore                           | PASSED | 300669=completed test/output/fastq/nanopore/.nxf.log
fastq/pacbio_hifi                        | PASSED | 300670=completed test/output/fastq/pacbio_hifi/.nxf.log
gvcf/liftover                            | PASSED | 300671=completed test/output/gvcf/liftover/.nxf.log
gvcf/multiproject                        | PASSED | 300672=completed test/output/gvcf/multiproject/.nxf.log
gvcf/trio                                | PASSED | 300673=completed test/output/gvcf/trio/.nxf.log
vcf/aip                                  | PASSED | 300674=completed test/output/vcf/aip/.nxf.log
vcf/chd7                                 | PASSED | 300675=completed test/output/vcf/chd7/.nxf.log
vcf/corner_cases                         | PASSED | 300676=completed test/output/vcf/corner_cases/.nxf.log
vcf/deb_register                         | PASSED | 300677=completed test/output/vcf/deb_register/.nxf.log
vcf/empty_input                          | PASSED | 300678=completed test/output/vcf/empty_input/.nxf.log
vcf/empty_output_filter_samples          | PASSED | 300679=completed test/output/vcf/empty_output_filter_samples/.nxf.log
vcf/empty_output_filter                  | PASSED | 300680=completed test/output/vcf/empty_output_filter/.nxf.log
vcf/filter_samples                       | PASSED | 300681=completed test/output/vcf/filter_samples/.nxf.log
vcf/liftover                             | PASSED | 300682=completed test/output/vcf/liftover/.nxf.log
vcf/multiproject_classify                | PASSED | 300683=completed test/output/vcf/multiproject_classify/.nxf.log
vcf/mvid                                 | PASSED | 300684=completed test/output/vcf/mvid/.nxf.log
vcf/str                                  | PASSED | 300685=completed test/output/vcf/str/.nxf.log
vcf/trio                                 | PASSED | 300686=completed test/output/vcf/trio/.nxf.log
vcf/vkgl_lb                              | PASSED | 300687=completed test/output/vcf/vkgl_lb/.nxf.log
vcf/vkgl_lp                              | PASSED | 300688=completed test/output/vcf/vkgl_lp/.nxf.log
vcf/vkgl_vus                             | PASSED | 300689=completed test/output/vcf/vkgl_vus/.nxf.log
done
```