### PR TITLE
fix:bump vip-report-template v7.0.5 to v7.0.6, improve decision tree exit node labelling

### DIFF
--- a/config/nxf_vcf.config
+++ b/config/nxf_vcf.config
@@ -111,7 +111,7 @@ params {
       include_crams = true
       max_records = ""
       max_samples = ""
-      template = "${projectDir}/resources/vip-report-template-v7.0.5.html"
+      template = "${projectDir}/resources/vip-report-template-v7.0.6.html"
       config = "${projectDir}/resources/vcf_report_config.json"
 			metadata = "${projectDir}/resources/field_metadata.json"
 

--- a/install.sh
+++ b/install.sh
@@ -147,7 +147,7 @@ download_files() {
   # update utils/install.sh when updating inheritance.tsv
   urls+=("df31eb0fe9ebd9ae26c8d6f5f7ba6e57" "resources/inheritance_20240115.tsv")
   urls+=("7138e76a38d6f67935699d06082ecacf" "resources/vep/cache/homo_sapiens_refseq_vep_111_GRCh38.tar.gz")
-  urls+=("6949ed9cbbdfdc4c7744ea4a6756687d" "resources/vip-report-template-v7.0.5.html")
+  urls+=("d79bde5e130fb268c3b96d0beba2abd2" "resources/vip-report-template-v7.0.6.html")
   # when modifying urls array, please keep list in 'ls -l' order
   for ((i = 0; i < ${#urls[@]}; i += 2)); do
     download_file "${base_url}" "${urls[i+1]}" "${urls[i+0]}" "${output_dir}" "${validate}"

--- a/resources/decision_tree_GRCh38.json
+++ b/resources/decision_tree_GRCh38.json
@@ -432,31 +432,31 @@
       "class": "LQ"
     },
     "exit_b": {
-      "label": "Benign",
+      "label": "B",
       "description": "Benign",
       "type": "LEAF",
       "class": "B"
     },
     "exit_lb": {
-      "label": "Likely Benign",
+      "label": "LB",
       "description": "Likely Benign",
       "type": "LEAF",
       "class": "LB"
     },
     "exit_vus": {
-      "label": "Uncertain Significance",
+      "label": "VUS",
       "description": "Uncertain Significance",
       "type": "LEAF",
       "class": "VUS"
     },
     "exit_lp": {
-      "label": "Likely Pathogenic",
+      "label": "LP",
       "description": "Likely Pathogenic",
       "type": "LEAF",
       "class": "LP"
     },
     "exit_p": {
-      "label": "Pathogenic",
+      "label": "P",
       "description": "Pathogenic",
       "type": "LEAF",
       "class": "P"


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 
