### PR TITLE
feat:bump Nextflow 24.04.2 to 24.10.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@
 
 # nextflow
 nextflow
-nextflow-*-all
+nextflow-*-dist
 
 # vip
 /vip

--- a/install.sh
+++ b/install.sh
@@ -91,7 +91,7 @@ download_files() {
   urls+=("57a7329781d3cb0e5491c5f84fd49dcd" "images/vcf-inheritance-matcher-3.3.2.sif")
   urls+=("9357590531fd4f1af1ab610ddafbdd3b" "images/vcf-report-7.2.0.sif")
   urls+=("7bffc236a7c65b2b2e2e5f7d64beaa87" "images/vep-111.0.sif")
-  urls+=("82be3c18406e7c027ee4cec83a723d71" "nextflow-24.04.2-all")
+  urls+=("4e8093cd83391e9d3679e1c7610184a7" "nextflow-24.10.2-dist")
   if [ "${assembly}" == "ALL" ] || [ "${assembly}" == "GRCh37" ]; then
     urls+=("11b8eb3d28482729dd035458ad5bda01" "resources/GRCh37/human_g1k_v37.fasta.gz")
     urls+=("772484cc07983aba1355c7fb50f176d4" "resources/GRCh37/human_g1k_v37.fasta.gz.fai")
@@ -199,7 +199,7 @@ create_symlinks() {
   local -r output_dir="${1}"
 
   # update utils/install.sh when updating nextflow
-  local -r file="nextflow-24.04.2-all"
+  local -r file="nextflow-24.10.2-dist"
   (cd "${output_dir}" && chmod +x "${file}") || echo "Failed to set permissions for ${file}"
   (cd "${output_dir}" && rm -f nextflow && ln -s ${file} "nextflow")
 

--- a/utils/install.sh
+++ b/utils/install.sh
@@ -59,8 +59,8 @@ install() {
   ln -s "${SCRIPT_DIR}/resources/gado" "${versionDir}/resources/gado"
 
   # prevent downloading shared resource
-  if [ -f "${SCRIPT_DIR}/resources/nextflow-24.04.2-all" ]; then
-    cp --link "${SCRIPT_DIR}/resources/nextflow-24.04.2-all" "${versionDir}"
+  if [ -f "${SCRIPT_DIR}/resources/nextflow-24.10.2-dist" ]; then
+    cp --link "${SCRIPT_DIR}/resources/nextflow-24.10.2-dist" "${versionDir}"
   fi
   if [ -f "${SCRIPT_DIR}/resources/hpo_20240404.tsv" ]; then
     cp --link "${SCRIPT_DIR}/resources/hpo_20240404.tsv" "${versionDir}/resources"
@@ -79,8 +79,8 @@ install() {
   fi
 
   # make resource shared
-  if [ -f "${versionDir}/nextflow-24.04.2-all" ] && [ ! -f "${SCRIPT_DIR}/resources/nextflow-24.04.2-all" ]; then
-    cp --link "${versionDir}/nextflow-24.04.2-all" "${SCRIPT_DIR}/resources"
+  if [ -f "${versionDir}/nextflow-24.10.2-dist" ] && [ ! -f "${SCRIPT_DIR}/resources/nextflow-24.10.2-dist" ]; then
+    cp --link "${versionDir}/nextflow-24.10.2-dist" "${SCRIPT_DIR}/resources"
   fi
   if [ -f "${versionDir}/resources/hpo_20240404.tsv" ] && [ ! -f "${SCRIPT_DIR}/resources/hpo_20240404.tsv" ]; then
     cp --link "${versionDir}/resources/hpo_20240404.tsv" "${SCRIPT_DIR}/resources"

--- a/vip.sh
+++ b/vip.sh
@@ -152,7 +152,7 @@ execute_workflow() {
   if [[ "${paramStub}" == "true" ]]; then
     args+=("-stub")
   fi
-  (cd "${paramOutput}" && APPTAINER_BIND="${APPTAINER_BIND-${envBind}}" APPTAINER_CACHEDIR="${envCacheDir}" NXF_VER="24.04.2" NXF_HOME="${envHome}" NXF_TEMP="${envTemp}" NXF_WORK="${envWork}" NXF_ENABLE_STRICT="${envStrict}" NXF_JVM_ARGS="${envJvm}" VIP_VERSION="${VIP_VERSION}" "${VIP_DIR}/nextflow" "${args[@]}")
+  (cd "${paramOutput}" && APPTAINER_BIND="${APPTAINER_BIND-${envBind}}" APPTAINER_CACHEDIR="${envCacheDir}" NXF_VER="24.10.2" NXF_HOME="${envHome}" NXF_TEMP="${envTemp}" NXF_WORK="${envWork}" NXF_ENABLE_STRICT="${envStrict}" NXF_JVM_ARGS="${envJvm}" VIP_VERSION="${VIP_VERSION}" "${VIP_DIR}/nextflow" "${args[@]}")
 }
 
 main() {


### PR DESCRIPTION
```
running tests ...
vcf/aip                                  | PASSED | 308964=completed test/output/vcf/aip/.nxf.log
vcf/chd7                                 | PASSED | 308965=completed test/output/vcf/chd7/.nxf.log
vcf/corner_cases                         | PASSED | 308966=completed test/output/vcf/corner_cases/.nxf.log
vcf/deb_register                         | PASSED | 308967=completed test/output/vcf/deb_register/.nxf.log
vcf/empty_input                          | PASSED | 308968=completed test/output/vcf/empty_input/.nxf.log
vcf/empty_output_filter_samples          | PASSED | 308969=completed test/output/vcf/empty_output_filter_samples/.nxf.log
vcf/empty_output_filter                  | PASSED | 308970=completed test/output/vcf/empty_output_filter/.nxf.log
vcf/filter_samples                       | PASSED | 308971=completed test/output/vcf/filter_samples/.nxf.log
vcf/liftover                             | PASSED | 308972=completed test/output/vcf/liftover/.nxf.log
vcf/multiproject_classify                | PASSED | 308973=completed test/output/vcf/multiproject_classify/.nxf.log
vcf/mvid                                 | PASSED | 308974=completed test/output/vcf/mvid/.nxf.log
vcf/str                                  | PASSED | 308975=completed test/output/vcf/str/.nxf.log
vcf/trio                                 | PASSED | 308976=completed test/output/vcf/trio/.nxf.log
vcf/vkgl_lb                              | PASSED | 308977=completed test/output/vcf/vkgl_lb/.nxf.log
vcf/vkgl_lp                              | PASSED | 308978=completed test/output/vcf/vkgl_lp/.nxf.log
vcf/vkgl_vus                             | PASSED | 308979=completed test/output/vcf/vkgl_vus/.nxf.log
done
```