### PR TITLE
chore:add online doc link to CLI usage

### DIFF
--- a/vip.sh
+++ b/vip.sh
@@ -23,7 +23,8 @@ usage() {
   -r, --resume                   resume execution using cached results (default: false)
   -s, --stub                     quickly prototype workflow logic using process script stubs
   -h, --help                     display this help and exit
-  -v, --version                  display version information and exit"
+  -v, --version                  display version information and exit
+For complete documentation, visit <https://molgenis.github.io/vip/>"
 }
 
 validate() {


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 
