### PR TITLE
Bump nextflow to 24.10.3

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -91,7 +91,7 @@ download_files() {
   urls+=("f1658b18249f5b90df6544413ae8174d" "images/vcf-inheritance-matcher-3.3.5.sif")
   urls+=("9357590531fd4f1af1ab610ddafbdd3b" "images/vcf-report-7.2.0.sif")
   urls+=("7bffc236a7c65b2b2e2e5f7d64beaa87" "images/vep-111.0.sif")
-  urls+=("4e8093cd83391e9d3679e1c7610184a7" "nextflow-24.10.2-dist")
+  urls+=("4db012dfaa1ed91371b73e3ab338aaad" "nextflow-24.10.3-dist")
   if [ "${assembly}" == "ALL" ] || [ "${assembly}" == "GRCh37" ]; then
     urls+=("11b8eb3d28482729dd035458ad5bda01" "resources/GRCh37/human_g1k_v37.fasta.gz")
     urls+=("772484cc07983aba1355c7fb50f176d4" "resources/GRCh37/human_g1k_v37.fasta.gz.fai")
@@ -199,7 +199,7 @@ create_symlinks() {
   local -r output_dir="${1}"
 
   # update utils/install.sh when updating nextflow
-  local -r file="nextflow-24.10.2-dist"
+  local -r file="nextflow-24.10.3-dist"
   (cd "${output_dir}" && chmod +x "${file}") || echo "Failed to set permissions for ${file}"
   (cd "${output_dir}" && rm -f nextflow && ln -s ${file} "nextflow")
 

--- a/utils/install.sh
+++ b/utils/install.sh
@@ -59,8 +59,8 @@ install() {
   ln -s "${SCRIPT_DIR}/resources/gado" "${versionDir}/resources/gado"
 
   # prevent downloading shared resource
-  if [ -f "${SCRIPT_DIR}/resources/nextflow-24.10.2-dist" ]; then
-    cp --link "${SCRIPT_DIR}/resources/nextflow-24.10.2-dist" "${versionDir}"
+  if [ -f "${SCRIPT_DIR}/resources/nextflow-24.10.3-dist" ]; then
+    cp --link "${SCRIPT_DIR}/resources/nextflow-24.10.3-dist" "${versionDir}"
   fi
   if [ -f "${SCRIPT_DIR}/resources/hpo_20240813.tsv" ]; then
     cp --link "${SCRIPT_DIR}/resources/hpo_20240813.tsv" "${versionDir}/resources"
@@ -79,8 +79,8 @@ install() {
   fi
 
   # make resource shared
-  if [ -f "${versionDir}/nextflow-24.10.2-dist" ] && [ ! -f "${SCRIPT_DIR}/resources/nextflow-24.10.2-dist" ]; then
-    cp --link "${versionDir}/nextflow-24.10.2-dist" "${SCRIPT_DIR}/resources"
+  if [ -f "${versionDir}/nextflow-24.10.3-dist" ] && [ ! -f "${SCRIPT_DIR}/resources/nextflow-24.10.3-dist" ]; then
+    cp --link "${versionDir}/nextflow-24.10.3-dist" "${SCRIPT_DIR}/resources"
   fi
   if [ -f "${versionDir}/resources/hpo_20240813.tsv" ] && [ ! -f "${SCRIPT_DIR}/resources/hpo_20240813.tsv" ]; then
     cp --link "${versionDir}/resources/hpo_20240813.tsv" "${SCRIPT_DIR}/resources"

--- a/vip.sh
+++ b/vip.sh
@@ -153,7 +153,7 @@ execute_workflow() {
   if [[ "${paramStub}" == "true" ]]; then
     args+=("-stub")
   fi
-  (cd "${paramOutput}" && APPTAINER_BIND="${APPTAINER_BIND-${envBind}}" APPTAINER_CACHEDIR="${envCacheDir}" NXF_VER="24.10.2" NXF_HOME="${envHome}" NXF_TEMP="${envTemp}" NXF_WORK="${envWork}" NXF_ENABLE_STRICT="${envStrict}" NXF_JVM_ARGS="${envJvm}" VIP_VERSION="${VIP_VERSION}" "${VIP_DIR}/nextflow" "${args[@]}")
+  (cd "${paramOutput}" && APPTAINER_BIND="${APPTAINER_BIND-${envBind}}" APPTAINER_CACHEDIR="${envCacheDir}" NXF_VER="24.10.3" NXF_HOME="${envHome}" NXF_TEMP="${envTemp}" NXF_WORK="${envWork}" NXF_ENABLE_STRICT="${envStrict}" NXF_JVM_ARGS="${envJvm}" VIP_VERSION="${VIP_VERSION}" "${VIP_DIR}/nextflow" "${args[@]}")
 }
 
 main() {


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 

vcf/aip                                  | PASSED | 317590=completed output/vcf/aip/.nxf.log
vcf/chd7                                 | PASSED | 317591=completed output/vcf/chd7/.nxf.log
vcf/corner_cases                         | PASSED | 317592=completed output/vcf/corner_cases/.nxf.log
vcf/deb_register                         | PASSED | 317593=completed output/vcf/deb_register/.nxf.log
vcf/empty_input                          | PASSED | 317594=completed output/vcf/empty_input/.nxf.log
vcf/empty_output_filter_samples          | PASSED | 317595=completed output/vcf/empty_output_filter_samples/.nxf.log
vcf/empty_output_filter                  | PASSED | 317596=completed output/vcf/empty_output_filter/.nxf.log
vcf/filter_samples                       | PASSED | 317597=completed output/vcf/filter_samples/.nxf.log
vcf/liftover                             | PASSED | 317598=completed output/vcf/liftover/.nxf.log
vcf/multiproject_classify                | PASSED | 317599=completed output/vcf/multiproject_classify/.nxf.log
vcf/mvid                                 | PASSED | 317600=completed output/vcf/mvid/.nxf.log
vcf/str                                  | PASSED | 317601=completed output/vcf/str/.nxf.log
vcf/trio                                 | PASSED | 317602=completed output/vcf/trio/.nxf.log
vcf/vkgl_lb                              | PASSED | 317603=completed output/vcf/vkgl_lb/.nxf.log
vcf/vkgl_lp                              | PASSED | 317604=completed output/vcf/vkgl_lp/.nxf.log
vcf/vkgl_vus                             | PASSED | 317605=completed output/vcf/vkgl_vus/.nxf.log
