### PR TITLE
fix:Liftover broken or uses wrong container & small other fixes

### DIFF
--- a/config/nxf.config
+++ b/config/nxf.config
@@ -10,7 +10,7 @@ env {
   CMD_BCFTOOLS = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/bcftools-1.20.sif bcftools"
   CMD_BGZIP = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/vep-111.0.sif bgzip"
   CMD_GLNEXUS="apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/glnexus_v1.4.5-patched.sif glnexus_cli"
-  CMD_PICARD = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/picard-3.1.1.sif"
+  CMD_PICARD = "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/picard-3.1.1_v2.sif"
   CMD_SAMTOOLS= "apptainer exec --no-mount home --bind \${TMPDIR} ${APPTAINER_CACHEDIR}/samtools-1.17-patch1.sif samtools"
 }
 

--- a/utils/create_gnomad.sh
+++ b/utils/create_gnomad.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 SCRIPT_DIR=$(dirname "$(realpath "$0")")
 
 APPTAINER_CACHEDIR="put_your_dir_here"
-CMD_BCFTOOLS="apptainer exec --no-mount home --bind /groups ${APPTAINER_CACHEDIR}/bcftools-1.19.sif bcftools"
+CMD_BCFTOOLS="apptainer exec --no-mount home --bind /groups ${APPTAINER_CACHEDIR}/bcftools-1.20.sif bcftools"
 CMD_BGZIP="apptainer exec --no-mount home --bind /groups ${APPTAINER_CACHEDIR}/vep-111.0.sif bgzip"
 CMD_TABIX="apptainer exec --no-mount home --bind /groups ${APPTAINER_CACHEDIR}/vep-111.0.sif tabix"
 

--- a/utils/create_mmi.sh
+++ b/utils/create_mmi.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 main() {
   local -r resourceDir="../vip/resources/GRCh38"
   cd "${resourceDir}"
-  APPTAINER_BIND=/groups apptainer exec "../vip/images/minimap2-2.26.sif" minimap2 -t 8 -d GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.gz.mmi GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.gz
+  APPTAINER_BIND=/groups apptainer exec "../vip/images/minimap2-2.27_v2.sif" minimap2 -t 8 -d GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.gz.mmi GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.gz
 }
 
 main "${@}"

--- a/utils/install.sh
+++ b/utils/install.sh
@@ -60,16 +60,16 @@ install() {
 
   # prevent downloading shared resource
   if [ -f "${SCRIPT_DIR}/resources/nextflow-24.10.3-dist" ]; then
-    cp --link "${SCRIPT_DIR}/resources/nextflow-24.10.3-dist" "${versionDir}"
+    cp --symbolic-link "${SCRIPT_DIR}/resources/nextflow-24.10.3-dist" "${versionDir}"
   fi
   if [ -f "${SCRIPT_DIR}/resources/hpo_20240813.tsv" ]; then
-    cp --link "${SCRIPT_DIR}/resources/hpo_20240813.tsv" "${versionDir}/resources"
+    cp --symbolic-link "${SCRIPT_DIR}/resources/hpo_20240813.tsv" "${versionDir}/resources"
   fi
   if [ -f "${SCRIPT_DIR}/resources/hpo_20240813_phenotypic_abnormality.tsv" ]; then
-      cp --link "${SCRIPT_DIR}/resources/hpo_20240813_phenotypic_abnormality.tsv" "${versionDir}/resources"
+      cp --symbolic-link "${SCRIPT_DIR}/resources/hpo_20240813_phenotypic_abnormality.tsv" "${versionDir}/resources"
     fi
   if [ -f "${SCRIPT_DIR}/resources/inheritance_20241211.tsv" ]; then
-    cp --link "${SCRIPT_DIR}/resources/inheritance_20241211.tsv" "${versionDir}/resources"
+    cp --symbolic-link "${SCRIPT_DIR}/resources/inheritance_20241211.tsv" "${versionDir}/resources"
   fi
 
   if [ "${validate}" == "false" ]; then
@@ -80,16 +80,16 @@ install() {
 
   # make resource shared
   if [ -f "${versionDir}/nextflow-24.10.3-dist" ] && [ ! -f "${SCRIPT_DIR}/resources/nextflow-24.10.3-dist" ]; then
-    cp --link "${versionDir}/nextflow-24.10.3-dist" "${SCRIPT_DIR}/resources"
+    cp --symbolic-link "${versionDir}/nextflow-24.10.3-dist" "${SCRIPT_DIR}/resources"
   fi
   if [ -f "${versionDir}/resources/hpo_20240813.tsv" ] && [ ! -f "${SCRIPT_DIR}/resources/hpo_20240813.tsv" ]; then
-    cp --link "${versionDir}/resources/hpo_20240813.tsv" "${SCRIPT_DIR}/resources"
+    cp --symbolic-link "${versionDir}/resources/hpo_20240813.tsv" "${SCRIPT_DIR}/resources"
   fi
   if [ -f "${versionDir}/resources/hpo_20240813_phenotypic_abnormality.tsv" ] && [ ! -f "${SCRIPT_DIR}/resources/hpo_20240813_phenotypic_abnormality.tsv" ]; then
-      cp --link "${versionDir}/resources/hpo_20240813_phenotypic_abnormality.tsv" "${SCRIPT_DIR}/resources"
+      cp --symbolic-link "${versionDir}/resources/hpo_20240813_phenotypic_abnormality.tsv" "${SCRIPT_DIR}/resources"
     fi
   if [ -f "${versionDir}/resources/inheritance_20241211.tsv" ] && [ ! -f "${SCRIPT_DIR}/resources/inheritance_20241211.tsv" ]; then
-    cp --link "${versionDir}/resources/inheritance_20241211.tsv" "${SCRIPT_DIR}/resources"
+    cp --symbolic-link "${versionDir}/resources/inheritance_20241211.tsv" "${SCRIPT_DIR}/resources"
   fi
 }
 

--- a/vip.sh
+++ b/vip.sh
@@ -7,7 +7,7 @@ SCRIPT_NAME="$(basename "$0")"
 # SCRIPT_DIR is incorrect when vip.sh is submitted as a Slurm job that is submitted as part of another Slurm job
 VIP_DIR="${VIP_DIR:-"${SCRIPT_DIR}"}"
 
-VIP_VERSION="8.1.0"
+VIP_VERSION="8.1.1"
 
 display_version() {
   echo -e "${VIP_VERSION}"


### PR DESCRIPTION
```
running tests ...
vcf/aip                                  | PASSED | 320507=completed test/output/vcf/aip/.nxf.log
vcf/chd7                                 | PASSED | 320508=completed test/output/vcf/chd7/.nxf.log
vcf/corner_cases                         | PASSED | 320509=completed test/output/vcf/corner_cases/.nxf.log
vcf/deb_register                         | PASSED | 320510=completed test/output/vcf/deb_register/.nxf.log
vcf/empty_input                          | PASSED | 320511=completed test/output/vcf/empty_input/.nxf.log
vcf/empty_output_filter_samples          | PASSED | 320512=completed test/output/vcf/empty_output_filter_samples/.nxf.log
vcf/empty_output_filter                  | PASSED | 320513=completed test/output/vcf/empty_output_filter/.nxf.log
vcf/filter_samples                       | PASSED | 320514=completed test/output/vcf/filter_samples/.nxf.log
vcf/liftover                             | PASSED | 320515=completed test/output/vcf/liftover/.nxf.log
vcf/multiproject_classify                | PASSED | 320516=completed test/output/vcf/multiproject_classify/.nxf.log
vcf/mvid                                 | PASSED | 320517=completed test/output/vcf/mvid/.nxf.log
vcf/str                                  | PASSED | 320518=completed test/output/vcf/str/.nxf.log
vcf/trio                                 | PASSED | 320519=completed test/output/vcf/trio/.nxf.log
vcf/vkgl_lb                              | FAILED | 320520=completed test/output/vcf/vkgl_lb/.nxf.log <-- failed due to https://github.com/molgenis/vip/issues/604
vcf/vkgl_lp                              | PASSED | 320521=completed test/output/vcf/vkgl_lp/.nxf.log
vcf/vkgl_vus                             | PASSED | 320522=completed test/output/vcf/vkgl_vus/.nxf.log
done
```