### PR TITLE
Update report template (7.1.1)

### DIFF
--- a/config/nxf_vcf.config
+++ b/config/nxf_vcf.config
@@ -111,7 +111,7 @@ params {
       include_crams = true
       max_records = ""
       max_samples = ""
-      template = "${projectDir}/resources/vip-report-template-v7.1.0.html"
+      template = "${projectDir}/resources/vip-report-template-v7.1.1.html"
       config = "${projectDir}/resources/vcf_report_config.json"
 			metadata = "${projectDir}/resources/field_metadata.json"
 

--- a/install.sh
+++ b/install.sh
@@ -147,7 +147,7 @@ download_files() {
   # update utils/install.sh when updating inheritance.tsv
   urls+=("519185b8b3b7688b9e99339d4045e3f0" "resources/inheritance_20241211.tsv")
   urls+=("7138e76a38d6f67935699d06082ecacf" "resources/vep/cache/homo_sapiens_refseq_vep_111_GRCh38.tar.gz")
-  urls+=("807a26ce4a3c44c59847081980506f35" "resources/vip-report-template-v7.1.0.html")
+  urls+=("4023abed0bccb31bf18bde3ddd1f2ed6" "resources/vip-report-template-v7.1.1.html")
   # when modifying urls array, please keep list in 'ls -l' order
   for ((i = 0; i < ${#urls[@]}; i += 2)); do
     download_file "${base_url}" "${urls[i+1]}" "${urls[i+0]}" "${output_dir}" "${validate}"


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 
vcf/aip | PASSED | 324066=completed output/vcf/aip/.nxf.log
vcf/chd7 | PASSED | 324067=completed output/vcf/chd7/.nxf.log
vcf/corner_cases | PASSED | 324068=completed output/vcf/corner_cases/.nxf.log
vcf/deb_register | PASSED | 324069=completed output/vcf/deb_register/.nxf.log
vcf/empty_input | PASSED | 324070=completed output/vcf/empty_input/.nxf.log
vcf/empty_output_filter_samples | PASSED | 324071=completed output/vcf/empty_output_filter_samples/.nxf.log
vcf/empty_output_filter | PASSED | 324072=completed output/vcf/empty_output_filter/.nxf.log
vcf/filter_samples | PASSED | 324073=completed output/vcf/filter_samples/.nxf.log
vcf/liftover | PASSED | 324074=completed output/vcf/liftover/.nxf.log
vcf/multiproject_classify | PASSED | 324075=completed output/vcf/multiproject_classify/.nxf.log
vcf/mvid | PASSED | 324076=completed output/vcf/mvid/.nxf.log
vcf/str | PASSED | 324077=completed output/vcf/str/.nxf.log
vcf/trio | PASSED | 324078=completed output/vcf/trio/.nxf.log
vcf/vkgl_lb | PASSED | 324079=completed output/vcf/vkgl_lb/.nxf.log
vcf/vkgl_lp | PASSED | 324080=completed output/vcf/vkgl_lp/.nxf.log
vcf/vkgl_vus | PASSED | 324081=completed output/vcf/vkgl_vus/.nxf.log
