### PR TITLE
move coverage output to /coverage

### DIFF
--- a/modules/cram/coverage.nf
+++ b/modules/cram/coverage.nf
@@ -1,7 +1,7 @@
 process coverage {
   label 'coverage'
   
-  publishDir "$params.output/intermediates", mode: 'link'
+  publishDir "$params.output/coverage", mode: 'link'
 
   input:
     tuple val(meta), path(cram), path(cramCrai), path(regions)


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 

cram/complex                             |        | 336334=running   output/cram/complex/.nxf.log
cram/multiproject                        | PASSED | 336335=completed output/cram/multiproject/.nxf.log
cram/nanopore_duo                        | PASSED | 336336=completed output/cram/nanopore_duo/.nxf.log
cram/nanopore                            | PASSED | 336337=completed output/cram/nanopore/.nxf.log
cram/single                              | PASSED | 336338=completed output/cram/single/.nxf.log
cram/trio                                |        | 336339=running   output/cram/trio/.nxf.log

