### PR TITLE
bump:inheritance_20241211.tsv to inheritance_20250131.tsv

### DIFF
--- a/config/nxf_vcf.config
+++ b/config/nxf_vcf.config
@@ -57,7 +57,7 @@ params {
       vep_cache_dir = "${VIP_DIR_DATA}/resources/vep/cache"
       vep_plugin_dir = "${VIP_DIR}/resources/vep/plugins"
       vep_plugin_hpo = "${VIP_DIR_DATA}/resources/hpo_20240813.tsv"
-      vep_plugin_inheritance = "${VIP_DIR_DATA}/resources/inheritance_20241211.tsv"
+      vep_plugin_inheritance = "${VIP_DIR_DATA}/resources/inheritance_20250131.tsv"
       vep_plugin_vkgl_mode = 1
       vep_plugin_green_db_enabled = false
 

--- a/install_data.sh
+++ b/install_data.sh
@@ -238,7 +238,7 @@ install_files() {
   data+=("ef2716679b0d9dca9df4b67af821f6f9" "resources/GRCh38/vkgl_consensus_20241001.tsv" "")
   data+=("d94140e762dfc6da23011718cccf2609" "resources/hpo_20240813.tsv" "")
   data+=("b62d33e85321a3104e58c129232e98df" "resources/hpo_20240813_phenotypic_abnormality.tsv" "")
-  data+=("519185b8b3b7688b9e99339d4045e3f0" "resources/inheritance_20241211.tsv" "")
+  data+=("ff9677b7756d4d6901441aad6a6e0f49" "resources/inheritance_20250131.tsv" "")
   data+=("7138e76a38d6f67935699d06082ecacf" "resources/vep/cache/homo_sapiens_refseq_vep_111_GRCh38.tar.gz" "postprocess_vep")
   data+=("4023abed0bccb31bf18bde3ddd1f2ed6" "resources/vip-report-template-v7.1.1.html" "")
 


### PR DESCRIPTION
```
running tests ...
vcf/aip                                  | PASSED | 337939=completed test/output/vcf/aip/.nxf.log
vcf/chd7                                 | PASSED | 337940=completed test/output/vcf/chd7/.nxf.log
vcf/corner_cases                         | PASSED | 337941=completed test/output/vcf/corner_cases/.nxf.log
vcf/deb_register                         | PASSED | 337942=completed test/output/vcf/deb_register/.nxf.log
vcf/empty_input                          | PASSED | 337943=completed test/output/vcf/empty_input/.nxf.log
vcf/empty_output_filter_samples          | PASSED | 337944=completed test/output/vcf/empty_output_filter_samples/.nxf.log
vcf/empty_output_filter                  | PASSED | 337945=completed test/output/vcf/empty_output_filter/.nxf.log
vcf/filter_samples                       | PASSED | 337946=completed test/output/vcf/filter_samples/.nxf.log
vcf/liftover                             | KAPUTT | 337947=failed    test/output/vcf/liftover/.nxf.log
vcf/multiproject_classify                | PASSED | 337948=completed test/output/vcf/multiproject_classify/.nxf.log
vcf/mvid                                 | PASSED | 337949=completed test/output/vcf/mvid/.nxf.log
vcf/str                                  | PASSED | 337950=completed test/output/vcf/str/.nxf.log
vcf/trio                                 | PASSED | 337951=completed test/output/vcf/trio/.nxf.log
vcf/vkgl_lb                              | PASSED | 337952=completed test/output/vcf/vkgl_lb/.nxf.log
vcf/vkgl_lp                              | PASSED | 337953=completed test/output/vcf/vkgl_lp/.nxf.log
vcf/vkgl_vus                             | PASSED | 337954=completed test/output/vcf/vkgl_vus/.nxf.log
done
```