### PR TITLE
Fix: Spectre VCF contains N ref nucleotides

### DIFF
--- a/modules/cram/templates/spectre_call.sh
+++ b/modules/cram/templates/spectre_call.sh
@@ -55,6 +55,7 @@ fixref () {
     (IFS=$'\t'; echo "${fields[*]}") >> "fixed_ref_output.vcf"
   done
   ${CMD_BCFTOOLS} view --output-type z --output "!{vcfOut}" --no-version --threads "!{task.cpus}" fixed_ref_output.vcf
+  rm "fixed_ref_output.vcf"
 }
 
 index () {

--- a/modules/cram/templates/spectre_call.sh
+++ b/modules/cram/templates/spectre_call.sh
@@ -34,7 +34,7 @@ call_copy_number_variation () {
 }
 
 fixref () {
-  # Workaround for TODO
+  # Workaround for https://github.com/fritzsedlazeck/Spectre/issues/42
   zcat "./spectre/!{sampleId}.vcf.gz" | \
   while IFS=$'\t' read -r -a fields
   do

--- a/modules/cram/templates/spectre_call.sh
+++ b/modules/cram/templates/spectre_call.sh
@@ -31,8 +31,30 @@ call_copy_number_variation () {
     fi
 
     ${CMD_SPECTRE} "${args[@]}"
+}
 
-    mv "./spectre/!{sampleId}.vcf.gz" "!{vcfOut}"
+fixref () {
+  # Workaround for TODO
+  zcat "./spectre/!{sampleId}.vcf.gz" | \
+  while IFS=$'\t' read -r -a fields
+  do
+    if [[ "${fields[0]}" != \#* && "${fields[3]}" == "N" ]]; then
+      ref=$(${CMD_SAMTOOLS} faidx "!{paramReference}" "${fields[0]}:${fields[1]}-${fields[1]}" | sed -n '2 p')
+      fields[3]="${ref}"
+      length="${#fields[4]}"
+      #Fix breakend ALTS
+      if [[ "${fields[4]}" == \]* && "${fields[4]}" == *N ]]; then
+        fields[4]="${fields[4]:0:(length-1)}${ref}"
+      elif [[ "${fields[4]}" == *\[ && "${fields[4]}" == N* ]]; then
+        fields[4]="${ref}${fields[4]:1:length}"
+      #Fix regular insertion ALT
+      elif [[ "${fields[4]}" == N* && "${length}" -gt 1 ]]; then
+        fields[4]="${ref}${fields[4]:1:length}"
+      fi
+    fi
+    (IFS=$'\t'; echo "${fields[*]}") >> "fixed_ref_output.vcf"
+  done
+  ${CMD_BCFTOOLS} view --output-type z --output "!{vcfOut}" --no-version --threads "!{task.cpus}" fixed_ref_output.vcf
 }
 
 index () {
@@ -43,6 +65,7 @@ index () {
 main() {
     mosdepth
     call_copy_number_variation
+    fixref
     index
 }
 


### PR DESCRIPTION
cram/complex                             | PASSED | 340714=completed output/cram/complex/.nxf.log
cram/multiproject                        | PASSED | 340715=completed output/cram/multiproject/.nxf.log
cram/nanopore_duo                        | PASSED | 340716=completed output/cram/nanopore_duo/.nxf.log
cram/nanopore                            | PASSED | 340717=completed output/cram/nanopore/.nxf.log
cram/single                              | PASSED | 340718=completed output/cram/single/.nxf.log
cram/trio                                | PASSED | 340719=completed output/cram/trio/.nxf.log

End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 
