### PR TITLE
Move default VIP_URL_DATA + add exomizer jar for AnnotSV + fix STR test

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -148,7 +148,7 @@ main() {
   check_requirements
   download_vip
 
-  VIP_DIR_DATA="${VIP_DIR_DATA}" VIP_URL_DATA="${VIP_URL_DATA}" bash "${VIP_DIR}/install_data.sh"
+  VIP_DIR_DATA="${VIP_DIR_DATA}" bash "${VIP_DIR}/install_data.sh"
 }
 
 main "${@}"

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,6 @@ SCRIPT_NAME="$(basename "${0}")"
 VIP_VER="${VIP_VER:-"v8.2.0"}"
 VIP_DIR="${VIP_DIR:-"${PWD}/vip/${VIP_VER//\//_}"}" # replace every forward slash with underscore
 VIP_DIR_DATA="${VIP_DIR_DATA:-"${PWD}/vip/data"}"
-VIP_URL_DATA="${VIP_URL_DATA:-"https://download.molgeniscloud.org/downloads/vip"}"
 
 # based on https://github.com/har7an/bash-semver-regex?tab=readme-ov-file#the-regex but without start ^ end $
 REGEX_SEM_VER="(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?"

--- a/install_data.sh
+++ b/install_data.sh
@@ -3,12 +3,12 @@ set -euo pipefail
 
 SCRIPT_NAME="$(basename "${0}")"
 
+VIP_URL_DATA="${VIP_URL_DATA:-"https://download.molgeniscloud.org/downloads/vip"}"
 VIP_DISK_SPACE_REQUIRED_GIGABYTES="280"
 
 if [[ "${#}" -eq "1" ]] && [[ "${*}" == "--help" ]]; then
   echo -e "usage: bash ${SCRIPT_NAME}.sh
   requirements:
-    VIP_DIR_DATA environment variable exists
     VIP_URL_DATA environment variable exists disk space
     ${VIP_DISK_SPACE_REQUIRED_GIGABYTES}G for initial install
   environment variables with default values:
@@ -193,6 +193,7 @@ install_files() {
   data+=("d9083115672ba278a0ad9baf01f747b3" "resources/annotsv/v3.4.4/2309_hg19.tar.gz" "postprocess_annotsv_hg19")
   data+=("ae755bea21ad8750ecd12a510104a889" "resources/annotsv/v3.4.4/2309_phenotype.zip" "postprocess_annotsv_phenotype")
   data+=("a0a4df58d3ed719121d935d1a28f363c" "resources/annotsv/v3.4.4/Annotations_Human_3.4.4.tar.gz" "postprocess_annotsv_annotations")
+  data+=("25d79667ba41aef0a418f75468e4b457" "resources/annotsv/v3.4.4/jar/exomiser-rest-prioritiser-12.1.0.jar" "")
   data+=("94bac97fe4dbc4ad1a74bde3afb55603" "resources/gado/v1.0.4_HPO_v2024-08-13/HPO_2024_08_13_prediction_matrix.cols.txt.gz" "")
   data+=("4461c232ae1be508e7aa1fb44ade2292" "resources/gado/v1.0.4_HPO_v2024-08-13/HPO_2024_08_13_prediction_matrix.datg" "")
   data+=("6d50fbb9b2f74221265dede2aae13e71" "resources/gado/v1.0.4_HPO_v2024-08-13/HPO_2024_08_13_prediction_matrix.rows.txt.gz" "")

--- a/install_data.sh
+++ b/install_data.sh
@@ -9,8 +9,8 @@ VIP_DISK_SPACE_REQUIRED_GIGABYTES="280"
 if [[ "${#}" -eq "1" ]] && [[ "${*}" == "--help" ]]; then
   echo -e "usage: bash ${SCRIPT_NAME}.sh
   requirements:
-    VIP_URL_DATA environment variable exists disk space
-    ${VIP_DISK_SPACE_REQUIRED_GIGABYTES}G for initial install
+    VIP_DIR_DATA environment variable exists
+    disk space ${VIP_DISK_SPACE_REQUIRED_GIGABYTES}G for initial install
   environment variables with default values:
     VIP_DIR_DATA ${VIP_DIR_DATA}
     VIP_URL_DATA ${VIP_URL_DATA}"

--- a/test/suites/vcf/resources/str.vcf
+++ b/test/suites/vcf/resources/str.vcf
@@ -17,6 +17,7 @@
 ##INFO=<ID=RL,Number=1,Type=Integer,Description="Reference length in bp">
 ##INFO=<ID=RU,Number=1,Type=String,Description="Repeat unit in the reference orientation">
 ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
+##INFO=<ID=RUMATCH,Number=0,Type=Flag,Description="Flag indicating if the called repeat unit matched the repeat unit in the loci bed file.">
 ##contig=<ID=chr22,length=50818468>
 ##ALT=<ID=STR13,Description="Allele comprised of 13 repeat units">
 ##ALT=<ID=STR23,Description="Allele comprised of 23 repeat units">

--- a/test/suites/vcf/str.sh
+++ b/test/suites/vcf/str.sh
@@ -11,7 +11,7 @@ args+=("--resume")
 vip.sh "${args[@]}" 1> /dev/null
 
 # compare expected to actual output and store result
-if [ "$(zcat "${OUTPUT_DIR}/vip.vcf.gz" | grep -vc "^#")" -eq 4 ]; then
+if [ "$(zcat "${OUTPUT_DIR}/vip.vcf.gz" | grep -vc "^#")" -eq 5 ]; then
   result="0"
 else
   result="1"

--- a/utils/apptainer/def/annotsv-3.4.4.def
+++ b/utils/apptainer/def/annotsv-3.4.4.def
@@ -12,6 +12,9 @@ From: sif/build/openjdk-21.sif
 %files from build
     /usr/local/bin/bcftools
 
+# When updating AnnotSV check if resources and exomizer jar should be updated (data/resources/annotsv/)
+# check if new jars were added to: https://github.com/lgmgeo/AnnotSV/blob/d20fd35999902f41b9d60d32ea26d0e4599cde49/Makefile#L200
+
 %post
     version_major=3
     version_minor=4


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 
vcf/aip                                  | PASSED | 341073=completed output/vcf/aip/.nxf.log
vcf/chd7                                 | PASSED | 341074=completed output/vcf/chd7/.nxf.log
vcf/corner_cases                         | PASSED | 341075=completed output/vcf/corner_cases/.nxf.log
vcf/deb_register                         | PASSED | 341076=completed output/vcf/deb_register/.nxf.log
vcf/empty_input                          | PASSED | 341077=completed output/vcf/empty_input/.nxf.log
vcf/empty_output_filter_samples          | PASSED | 341078=completed output/vcf/empty_output_filter_samples/.nxf.log
vcf/empty_output_filter                  | PASSED | 341079=completed output/vcf/empty_output_filter/.nxf.log
vcf/filter_samples                       | PASSED | 341080=completed output/vcf/filter_samples/.nxf.log
vcf/liftover                             | KAPUTT | 341081=failed    output/vcf/liftover/.nxf.log
vcf/multiproject_classify                | PASSED | 341082=completed output/vcf/multiproject_classify/.nxf.log
vcf/mvid                                 | PASSED | 341083=completed output/vcf/mvid/.nxf.log
vcf/str                                  | KAPUTT | 341084=failed    output/vcf/str/.nxf.log
vcf/trio                                 | PASSED | 341085=completed output/vcf/trio/.nxf.log
vcf/vkgl_lb                              | PASSED | 341086=completed output/vcf/vkgl_lb/.nxf.log
vcf/vkgl_lp                              | PASSED | 341087=completed output/vcf/vkgl_lp/.nxf.log
vcf/vkgl_vus                             | PASSED | 341088=completed output/vcf/vkgl_vus/.nxf.log

cram/multiproject                        | PASSED | 340555=completed output/cram/multiproject/.nxf.log
cram/nanopore_duo                        | PASSED | 340556=completed output/cram/nanopore_duo/.nxf.log
cram/complex                             | PASSED | 340554=completed output/cram/complex/.nxf.log
cram/multiproject                        | PASSED | 340555=completed output/cram/multiproject/.nxf.log
cram/nanopore_duo                        | PASSED | 340556=completed output/cram/nanopore_duo/.nxf.log
cram/nanopore                            | PASSED | 340557=completed output/cram/nanopore/.nxf.log
cram/single                              | PASSED | 340558=completed output/cram/single/.nxf.log
cram/trio                                | PASSED | 340559=completed output/cram/trio/.nxf.log

vcf/str                                  | PASSED | 341464=completed output/vcf/str/.nxf.log
