### PR TITLE
Update straglr to 1.4.5-v2

### DIFF
--- a/config/nxf_call_str.config
+++ b/config/nxf_call_str.config
@@ -2,7 +2,7 @@ includeConfig 'nxf.config'
 
 env {
   CMD_EXPANSIONHUNTER = "apptainer exec --no-mount home ${APPTAINER_CACHEDIR}/expansionhunter-5.0.0_v2.sif ExpansionHunter"
-  CMD_STRAGLR="apptainer exec --no-mount home ${APPTAINER_CACHEDIR}/straglr-1.4.5-vip-v1.sif straglr-genotype"
+  CMD_STRAGLR="apptainer exec --no-mount home ${APPTAINER_CACHEDIR}/straglr-1.4.5-vip-v2.sif straglr-genotype"
 }
 
 params {

--- a/install_data.sh
+++ b/install_data.sh
@@ -182,7 +182,7 @@ install_files() {
   data+=("9a4b685b26744113d3ea0a3904c02706" "images/samtools-1.17-patch1.sif" "")
   data+=("ccbb1e1887f11d9e3cda1ae8bf2d67da" "images/seqtk-1.4_v2.sif" "")
   data+=("4d58cc7a4e3e497a245095a62562e27e" "images/spectre-0.2.1-patched_v2.sif" "")
-  data+=("FIXME" "images/straglr-1.4.5-vip-v2.sif" "")
+  data+=("f17512262ce33e50ca920163011e9ea3" "images/straglr-1.4.5-vip-v2.sif" "")
   data+=("8d55b74c7f27785824874bca5a88ffd2" "images/stranger-0.9.3.sif" "")
   data+=("b3251b3329e92d5c67b383353d3d3f5d" "images/vcf-decision-tree-5.1.3.sif" "")
   data+=("5cc8e497f1ed2da8d284357aa97db7d6" "images/vcf-inheritance-matcher-3.3.6.sif" "")

--- a/install_data.sh
+++ b/install_data.sh
@@ -182,7 +182,7 @@ install_files() {
   data+=("9a4b685b26744113d3ea0a3904c02706" "images/samtools-1.17-patch1.sif" "")
   data+=("ccbb1e1887f11d9e3cda1ae8bf2d67da" "images/seqtk-1.4_v2.sif" "")
   data+=("4d58cc7a4e3e497a245095a62562e27e" "images/spectre-0.2.1-patched_v2.sif" "")
-  data+=("a11f9e4a1288d92963d63c9d8bfe3a1d" "images/straglr-1.4.5-vip-v1.sif" "")
+  data+=("FIXME" "images/straglr-1.4.5-vip-v2.sif" "")
   data+=("8d55b74c7f27785824874bca5a88ffd2" "images/stranger-0.9.3.sif" "")
   data+=("b3251b3329e92d5c67b383353d3d3f5d" "images/vcf-decision-tree-5.1.3.sif" "")
   data+=("5cc8e497f1ed2da8d284357aa97db7d6" "images/vcf-inheritance-matcher-3.3.6.sif" "")

--- a/utils/apptainer/build.sh
+++ b/utils/apptainer/build.sh
@@ -95,7 +95,7 @@ main() {
   images+=("seqtk-1.4_v2")
   images+=("spectre-0.2.1-patched_v2")
   images+=("stranger-0.9.3")
-  images+=("straglr-1.4.5-vip-v1")
+  images+=("straglr-1.4.5-vip-v2")
   images+=("vcf-decision-tree-5.1.3")
   images+=("vcf-inheritance-matcher-3.3.6")
   images+=("vcf-report-7.2.0")

--- a/utils/apptainer/def/straglr-1.4.5-vip-v2.def
+++ b/utils/apptainer/def/straglr-1.4.5-vip-v2.def
@@ -11,8 +11,8 @@ From: sif/build/ubuntu-22.04.sif
     curl -Ls -o /opt/trf/trf "https://github.com/Benson-Genomics-Lab/TRF/releases/download/v4.09.1/trf409.linux64"
     chmod +x /opt/trf/trf
 
-    #dd93a55101786454f7d205848ed3aec658c277bf == 1.4.5-vip-v1
-    pip install git+https://github.com/molgenis/straglr.git@dd93a55101786454f7d205848ed3aec658c277bf#egg=straglr
+    #1c754105bc64ad27327fa541e1fc1c96cbe4122e == 1.4.5-vip-v2
+    pip install git+https://github.com/molgenis/straglr.git@1c754105bc64ad27327fa541e1fc1c96cbe4122e#egg=straglr
 
     # cleanup
     pip cache purge


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 

cram/complex                             | PASSED | 345498=completed output/cram/complex/.nxf.log
cram/multiproject                        | PASSED | 345499=completed output/cram/multiproject/.nxf.log
cram/nanopore_duo                        | PASSED | 345500=completed output/cram/nanopore_duo/.nxf.log
cram/nanopore                            | PASSED | 345501=completed output/cram/nanopore/.nxf.log
cram/single                              | PASSED | 345502=completed output/cram/single/.nxf.log
cram/trio                                | PASSED | 345503=completed output/cram/trio/.nxf.log
done
