### PR TITLE
fix#701 FORMAT/VIG value can be empty instead of missing value

### DIFF
--- a/modules/vcf/templates/report.sh
+++ b/modules/vcf/templates/report.sh
@@ -11,9 +11,9 @@ create_vcf () {
   args+=("--output" "!{vcfOut}")
   args+=("--no-version")
   args+=("--threads" "!{task.cpus}")
-  args+=("!{vcf}")
 
-  ${CMD_BCFTOOLS} "${args[@]}"
+  # workaround for https://github.com/samtools/bcftools/issues/2385
+  ${CMD_BCFTOOLS} view --no-version --threads "!{task.cpus}" "!{vcf}" | ${CMD_BCFTOOLS} "${args[@]}"
 }
 
 index () {


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 
