### PR TITLE
fix: install.sh VIP_URL_DATA: unbound variable

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -27,8 +27,7 @@ usage() {
     VIP_VER      ${VIP_VER}
     VIP_DIR      ${VIP_DIR}
     VIP_DIR_DATA ${VIP_DIR_DATA}
-    VIP_URL_DATA ${VIP_URL_DATA}
-    if --data_dir, --version, --vip_dir and/or --url are not provided."
+    if --version, --vip_dir and/or --data_dir are not provided."
   exit 0
 }
 
@@ -142,7 +141,9 @@ download_vip() {
 
 main() {
   local -r args=$(getopt -a -n install -o i:d:u:v:ph --long vip_dir:,data_dir:,url:,version:,prune,help -- "$@")
-  is_prune_enabled="false"
+
+  local is_prune_enabled="false"
+  local url=""
 
   eval set -- "${args}"
   while :; do
@@ -155,7 +156,7 @@ main() {
       shift
       ;;
     -u | --url)
-      VIP_URL_DATA="$2"
+      url="$2"
       shift 2
       ;;
     -d | --data_dir)
@@ -193,7 +194,9 @@ main() {
     data_args+=("--prune")
   fi
   data_args+=("--data_dir" "${VIP_DIR_DATA}")
-  data_args+=("--url" "${VIP_URL_DATA}")
+  if [[ -n "${url}" ]]; then
+    data_args+=("--url" "${url}")
+  fi
 
   VIP_DIR_DATA="${VIP_DIR_DATA}" bash "${VIP_DIR}/install_data.sh" "${data_args[@]}"
 }

--- a/install.sh
+++ b/install.sh
@@ -198,7 +198,7 @@ main() {
     data_args+=("--url" "${url}")
   fi
 
-  VIP_DIR_DATA="${VIP_DIR_DATA}" bash "${VIP_DIR}/install_data.sh" "${data_args[@]}"
+  bash "${VIP_DIR}/install_data.sh" "${data_args[@]}"
 }
 
 main "${@}"


### PR DESCRIPTION
```
$ ./install.sh -v fix/install_sh
VIP fix/install_sh installation running...
VIP fix/install_sh installation completed, execute vip/fix_install_sh/vip.sh to get started
Slurm job scheduling system detected and will be used automatically
```

```
$ bash vip/fix_install_sh/install.sh --help
usage: bash install.sh.sh [-v <vip_version>] [-i <vip_install_dir>] [-d <data_dir>] [-u <url>] [-p]
  -p, --prune     remove resources from previous VIP installs that are not required for this version.
  -u, --url       base url to download VIP resources from
  -d, --data_dir  directory where VIP resources should be installed
  -i, --vip_dir   directory where the VIP software should be installed
  -v, --version   VIP version to be installed
  -h, --help

  requirements:
    apptainer    see https://apptainer.org/
    bash         >= 3.2
    java         >= 11
  environment variables with default values:
    VIP_VER      v8.2.0
    VIP_DIR      /groups/umcg-vipt/tmp05/projects/vip_validation/vip/fix_install_sh/vip/v8.2.0
    VIP_DIR_DATA /groups/umcg-vipt/tmp05/projects/vip_validation/vip/fix_install_sh/vip/data
    if --version, --vip_dir and/or --data_dir are not provided.
VIP v8.2.0 installation completed, execute vip/v8.2.0/vip.sh to get started
Slurm job scheduling system detected and will be used automatically
```