### PR TITLE
fix: don't show 'SV type' column for SNV in report

### DIFF
--- a/resources/vcf_report_config.json
+++ b/resources/vcf_report_config.json
@@ -204,10 +204,6 @@
           "name": "ref"
         },
         {
-          "type": "info",
-          "name": "SVTYPE"
-        },
-        {
           "type": "composed",
           "name": "genotype",
           "label": "Proband"


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 
