### PR TITLE
Sort vcf after normalization

### DIFF
--- a/modules/vcf/templates/normalize.sh
+++ b/modules/vcf/templates/normalize.sh
@@ -12,14 +12,12 @@ normalize () {
     args+=("--check-ref" "e")
   fi
   args+=("--fasta-ref" "!{refSeqPath}")
-  args+=("--output-type" "z")
-  args+=("--output" "!{vcfOut}")
   args+=("--no-version")
   args+=("--old-rec-tag" "OLD_REC") # if variant is normalized, keep the original location in this field
   args+=("--threads" "!{task.cpus}")
   args+=("!{vcf}")
-
-  ${CMD_BCFTOOLS} "${args[@]}"
+  # pipe to sort since order can change due to normalization
+  ${CMD_BCFTOOLS} "${args[@]}" | ${CMD_BCFTOOLS} sort --temp-dir . --max-mem "!{task.memory.toGiga() - 1}G" --output-type z --output "!{vcfOut}"
 }
 
 index () {

--- a/modules/vcf/templates/normalize.sh
+++ b/modules/vcf/templates/normalize.sh
@@ -13,11 +13,18 @@ normalize () {
   fi
   args+=("--fasta-ref" "!{refSeqPath}")
   args+=("--no-version")
+  args+=("--output-type" "z")
+  args+=("--output" "unsorted_!{vcfOut}")
   args+=("--old-rec-tag" "OLD_REC") # if variant is normalized, keep the original location in this field
   args+=("--threads" "!{task.cpus}")
   args+=("!{vcf}")
-  # pipe to sort since order can change due to normalization
-  ${CMD_BCFTOOLS} "${args[@]}" | ${CMD_BCFTOOLS} sort --temp-dir . --max-mem "!{task.memory.toGiga() - 1}G" --output-type z --output "!{vcfOut}"
+  
+  ${CMD_BCFTOOLS} "${args[@]}"
+}
+
+sort () {
+  # sort since order can change due to normalization, cant pipe due to concurrent modification cause by 'norm' multithreading
+  ${CMD_BCFTOOLS} sort --temp-dir . --max-mem "!{task.memory.toGiga() - 1}G" --output-type z --output "!{vcfOut}" "unsorted_!{vcfOut}"
 }
 
 index () {
@@ -27,6 +34,7 @@ index () {
 
 main() {
   normalize
+  sort
   index
 }
 


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 
vcf/aip                                  | PASSED | 377217=completed output/vcf/aip/.nxf.log
vcf/chd7                                 | PASSED | 377218=completed output/vcf/chd7/.nxf.log
vcf/corner_cases                         | PASSED | 377219=completed output/vcf/corner_cases/.nxf.log
vcf/deb_register                         | PASSED | 377220=completed output/vcf/deb_register/.nxf.log
vcf/empty_input                          | PASSED | 377221=completed output/vcf/empty_input/.nxf.log
vcf/empty_output_filter_samples          | PASSED | 377222=completed output/vcf/empty_output_filter_samples/.nxf.log
vcf/empty_output_filter                  | PASSED | 377223=completed output/vcf/empty_output_filter/.nxf.log
vcf/filter_samples                       | PASSED | 377224=completed output/vcf/filter_samples/.nxf.log
vcf/liftover                             | PASSED | 377225=completed output/vcf/liftover/.nxf.log
vcf/multiproject_classify                | PASSED | 377226=completed output/vcf/multiproject_classify/.nxf.log
vcf/mvid                                 | PASSED | 377227=completed output/vcf/mvid/.nxf.log
vcf/str                                  | PASSED | 377228=completed output/vcf/str/.nxf.log
vcf/trio                                 | PASSED | 377229=completed output/vcf/trio/.nxf.log
vcf/vkgl_lb                              | PASSED | 377230=completed output/vcf/vkgl_lb/.nxf.log
vcf/vkgl_lp                              | PASSED | 377231=completed output/vcf/vkgl_lp/.nxf.log
vcf/vkgl_vus                             | PASSED | 377232=completed output/vcf/vkgl_vus/.nxf.log

