### PR TITLE
Fix: install.sh help prints success message

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -31,9 +31,6 @@ usage() {
   exit 0
 }
 
-# set trap only after print usage check
-trap "handle_exit" EXIT
-
 detect_slurm() {
   # shellcheck disable=SC2317
   if command -v sbatch &> /dev/null; then
@@ -199,6 +196,8 @@ main() {
   fi
 
   bash "${VIP_DIR}/install_data.sh" "${data_args[@]}"
+
+  trap "handle_exit" EXIT
 }
 
 main "${@}"

--- a/install.sh
+++ b/install.sh
@@ -31,13 +31,6 @@ usage() {
   exit 0
 }
 
-detect_slurm() {
-  # shellcheck disable=SC2317
-  if command -v sbatch &> /dev/null; then
-    echo -e "Slurm job sch_duling system detected and will be used automatically"
-  fi
-}
-
 handle_exit() {
   local -r exit_code=$?
   if [[ ${exit_code} -eq 0 ]]; then
@@ -91,6 +84,7 @@ check_requirements_java() {
 }
 
 detect_slurm() {
+  # shellcheck disable=SC2317
   if command -v sbatch &> /dev/null; then
     echo -e "Slurm job scheduling system detected and will be used automatically"
   fi

--- a/install.sh
+++ b/install.sh
@@ -34,7 +34,7 @@ usage() {
 detect_slurm() {
   # shellcheck disable=SC2317
   if command -v sbatch &> /dev/null; then
-    echo -e "Slurm job scheduling system detected and will be used automatically"
+    echo -e "Slurm job sch_duling system detected and will be used automatically"
   fi
 }
 


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 

```
>bash install.sh 
VIP v8.3.1 installation running...
VIP v8.3.1 installation completed, execute vip/v8.3.1/vip.sh to get started
Slurm job scheduling system detected and will be used automatically

>bash install.sh  --help
usage: bash install.sh [-v <vip_version>] [-i <vip_install_dir>] [-d <data_dir>] [-u <url>] [-p]
  -p, --prune     remove resources from previous VIP installs that are not required for this version.
  -u, --url       base url to download VIP resources from
  -d, --data_dir  directory where VIP resources should be installed
  -i, --vip_dir   directory where the VIP software should be installed
  -v, --version   VIP version to be installed
  -h, --help

  requirements:
    apptainer    see https://apptainer.org/
    bash         >= 3.2
    java         >= 11
  environment variables with default values:
    VIP_VER      v8.3.1
    VIP_DIR      /groups/umcg-gcc/tmp01/projects/vipt/umcg-bcharbon/vip/vip/v8.3.1
    VIP_DIR_DATA /groups/umcg-gcc/tmp01/projects/vipt/vip/data
    if --version, --vip_dir and/or --data_dir are not provided.
```



