### PR TITLE
fix: Only publish fastp reports

### DIFF
--- a/modules/fastq/fastp.nf
+++ b/modules/fastq/fastp.nf
@@ -1,7 +1,7 @@
 process fastp {
   label 'fastp'
 
-  publishDir "$params.output/intermediates/fastp", mode: 'link'
+  publishDir "$params.output/intermediates/fastp", mode: 'link', pattern: "*_report.*"
 
   input:
     tuple val(meta), path(fastqs, arity: '1..*')


### PR DESCRIPTION
End-to-end tests are not executed by Travis CI, please execute manually:
- [ ] `APPTAINER_BIND=$PWD bash test/test.sh` passes
- [ ] Updated documentation 
