### PR TITLE
Only publish fastp reports

### DIFF
--- a/modules/fastq/fastp.nf
+++ b/modules/fastq/fastp.nf
@@ -1,7 +1,7 @@
 process fastp {
   label 'fastp'
 
-  publishDir "$params.output/intermediates/fastp", mode: 'link', pattern: "*_report.*"
+  publishDir "$params.output/intermediates/fastp", mode: 'link', pattern: "*.{json,html}"
 
   input:
     tuple val(meta), path(fastqs, arity: '1..*')


### PR DESCRIPTION
Before submitting this PR, please make sure:
- [ ] You have updated documentation for new/updated/removed features
- [ ] You have added tests
- [ ] You have manually run tests using `bash test/test.sh` and verified that all tests pass
fastq/nanopore_adaptive_sampling         | PASSED | 406980=completed output/fastq/nanopore_adaptive_sampling/.nxf.log

```
[umcg-bcharbon@betabarrel intermediates]$ tree
.
├── fastp
│   ├── vip_fam0_HG002_report.html
│   └── vip_fam0_HG002_report.json
├── HG002_snv.g.vcf.gz
├── HG002_snv.g.vcf.gz.csi
├── HG002_snv.g.vcf.gz.stats
├── vip_annotations.vcf.gz
├── vip_annotations.vcf.gz.csi
├── vip_classifications.vcf.gz
├── vip_classifications.vcf.gz.csi
├── vip_fam0_HG002_cnv.vcf.gz
├── vip_fam0_HG002_cnv.vcf.gz.csi
├── vip_fam0_HG002_cnv.vcf.gz.stats
├── vip_fam0_HG002.cram
├── vip_fam0_HG002.cram.crai
├── vip_fam0_HG002.cram.stats
├── vip_fam0_HG002_str.tsv
├── vip_fam0_HG002_str.vcf.gz
├── vip_fam0_HG002_str.vcf.gz.csi
├── vip_fam0_HG002_str.vcf.gz.stats
├── vip_fam0_HG002_sv.vcf.gz
├── vip_fam0_HG002_sv.vcf.gz.csi
├── vip_fam0_HG002_sv.vcf.gz.stats
├── vip_sample_classifications.vcf.gz
├── vip_sample_classifications.vcf.gz.csi
├── vip_snv.vcf.gz
├── vip_snv.vcf.gz.csi
├── vip_snv.vcf.gz.stats
├── vip.vcf.gz
├── vip.vcf.gz.csi
└── vip.vcf.gz.stats
```
