### PR TITLE
Fix non coding plugins end pos score

### DIFF
--- a/resources/vep/plugins/ReMM.pm
+++ b/resources/vep/plugins/ReMM.pm
@@ -86,7 +86,7 @@ sub run {
   }
   else{
     my $scoreStart = getScore($chr, $start);
-    my $scoreEnd = getScore($chr, $start);
+    my $scoreEnd = getScore($chr, $end);
     if(length $scoreStart && length $scoreEnd){
         $score = $scoreStart > $scoreEnd ? $scoreStart : $scoreEnd;
     }elsif(length $scoreStart){

--- a/resources/vep/plugins/ncER.pm
+++ b/resources/vep/plugins/ncER.pm
@@ -93,7 +93,7 @@ sub run {
   }
   else{
     my $scoreStart = getScore($chr, $start);
-    my $scoreEnd = getScore($chr, $start);
+    my $scoreEnd = getScore($chr, $end);
     if(length $scoreStart && length $scoreEnd){
         $score = $scoreStart > $scoreEnd ? $scoreStart : $scoreEnd;
     }elsif(length $scoreStart){


### PR DESCRIPTION
Before submitting this PR, please make sure:
- [ ] You have updated documentation for new/updated/removed features
- [ ] You have added tests
- [ ] You have manually run tests using `bash test/test.sh` and verified that all tests pass

vcf/aip                                  | PASSED | 410608=completed output/vcf/aip/.nxf.log
vcf/chd7                                 | PASSED | 410609=completed output/vcf/chd7/.nxf.log
vcf/corner_cases                         | PASSED | 410610=completed output/vcf/corner_cases/.nxf.log
vcf/deb_register                         | PASSED | 410611=completed output/vcf/deb_register/.nxf.log
vcf/empty_input                          | PASSED | 410612=completed output/vcf/empty_input/.nxf.log
vcf/empty_output_filter_samples          | PASSED | 410613=completed output/vcf/empty_output_filter_samples/.nxf.log
vcf/empty_output_filter                  | PASSED | 410614=completed output/vcf/empty_output_filter/.nxf.log
vcf/filter_samples                       | PASSED | 410615=completed output/vcf/filter_samples/.nxf.log
vcf/liftover                             | PASSED | 410616=completed output/vcf/liftover/.nxf.log
vcf/multiproject_classify                | PASSED | 410617=completed output/vcf/multiproject_classify/.nxf.log
vcf/mvid                                 | PASSED | 410618=completed output/vcf/mvid/.nxf.log
vcf/no_spliceai                          | PASSED | 410619=completed output/vcf/no_spliceai/.nxf.log
vcf/str                                  | PASSED | 410620=completed output/vcf/str/.nxf.log
vcf/trio                                 | PASSED | 410621=completed output/vcf/trio/.nxf.log
vcf/vkgl_lb                              | PASSED | 410622=completed output/vcf/vkgl_lb/.nxf.log
vcf/vkgl_lp                              | PASSED | 410623=completed output/vcf/vkgl_lp/.nxf.log
vcf/vkgl_vus                             | PASSED | 410624=completed output/vcf/vkgl_vus/.nxf.log
