### PR TITLE
fix: cram/concat_vcf removes records with same chr-pos-ref but diff alt

### DIFF
--- a/modules/cram/templates/concat_vcf.sh
+++ b/modules/cram/templates/concat_vcf.sh
@@ -19,7 +19,7 @@ concat () {
 }
 
 bcftools_sort () {
-  ${CMD_BCFTOOLS} norm --do-not-normalize --rm-dup all --no-version --threads "!{task.cpus}" "unsorted_!{vcfOut}" | ${CMD_BCFTOOLS} sort --temp-dir . --max-mem "!{task.memory.toGiga() - 1}G" --output-type z --output "!{vcfOut}"
+  ${CMD_BCFTOOLS} norm --do-not-normalize --rm-dup exact --no-version --threads "!{task.cpus}" "unsorted_!{vcfOut}" | ${CMD_BCFTOOLS} sort --temp-dir . --max-mem "!{task.memory.toGiga() - 1}G" --output-type z --output "!{vcfOut}"
 }
 
 index () {


### PR DESCRIPTION
```
running tests ...
cram/complex                             | PASSED | 451938=completed vip/fix_concat_vcf/test/output/cram/complex/.nxf.log
cram/multiproject                        | PASSED | 451939=completed vip/fix_concat_vcf/test/output/cram/multiproject/.nxf.log
cram/nanopore_duo                        | PASSED | 451940=completed vip/fix_concat_vcf/test/output/cram/nanopore_duo/.nxf.log
cram/nanopore                            | PASSED | 451941=completed vip/fix_concat_vcf/test/output/cram/nanopore/.nxf.log
cram/single                              | PASSED | 451942=completed vip/fix_concat_vcf/test/output/cram/single/.nxf.log
cram/trio                                | PASSED | 451943=completed vip/fix_concat_vcf/test/output/cram/trio/.nxf.log
fastq/nanopore_adaptive_sampling         | PASSED | 451944=completed vip/fix_concat_vcf/test/output/fastq/nanopore_adaptive_sampling/.nxf.log
fastq/nanopore                           | PASSED | 451945=completed vip/fix_concat_vcf/test/output/fastq/nanopore/.nxf.log
fastq/pacbio_hifi                        | PASSED | 451946=completed vip/fix_concat_vcf/test/output/fastq/pacbio_hifi/.nxf.log
done
```