### PR TITLE
Fix GreenDb index bug

### DIFF
--- a/resources/vep/plugins/GREEN_DB.pm
+++ b/resources/vep/plugins/GREEN_DB.pm
@@ -69,8 +69,7 @@ sub get_scores {
   if($start <= $end){
     @data = @{$self->get_data($chr, $start, $end)};
   }else{
-    #structural variant on the reverse strand
-    @data = @{$self->get_data($chr, $end, $start)};
+    die "ERROR: Encountered an end position before the stop position";
   }
 
   my $size = @data;
@@ -83,7 +82,7 @@ sub get_scores {
   #if data is present
   if($size >= 1){
     for my $i (0 .. $#data) {
-      my @line = split("\t", $data[0]);
+      my @line = split("\t", $data[$i]);
       #if no value present for the type of region (line[4]), or the current line has a higher score (line[6]) for this type of region, add/overwrite it in the result.
       if(!$values->{$line[4]} || $line[8] > $values->{$line[4]}){
         if($line[8] ne "NA"){


### PR DESCRIPTION
Before submitting this PR, please make sure:
- [ ] You have updated documentation for new/updated/removed features
- [ ] You have added tests
- [ ] You have manually run tests using `bash test/test.sh` and verified that all tests pass

vcf/aip                                  | PASSED | 6400338=completed output/vcf/aip/.nxf.log
vcf/chd7                                 | PASSED | 6400339=completed output/vcf/chd7/.nxf.log
vcf/corner_cases                         | PASSED | 6400340=completed output/vcf/corner_cases/.nxf.log
vcf/deb_register                         | PASSED | 6400341=completed output/vcf/deb_register/.nxf.log
vcf/empty_input                          | PASSED | 6400342=completed output/vcf/empty_input/.nxf.log
vcf/empty_output_filter_samples          | PASSED | 6400343=completed output/vcf/empty_output_filter_samples/.nxf.log
vcf/empty_output_filter                  | PASSED | 6400344=completed output/vcf/empty_output_filter/.nxf.log
vcf/filter_samples                       | PASSED | 6400345=completed output/vcf/filter_samples/.nxf.log
vcf/jvar_blb                             | PASSED | 6400346=completed output/vcf/jvar_blb/.nxf.log
vcf/jvar_plp                             | PASSED | 6400347=completed output/vcf/jvar_plp/.nxf.log
vcf/liftover                             | PASSED | 6400348=completed output/vcf/liftover/.nxf.log
vcf/mtdna_blb                            | PASSED | 6400349=completed output/vcf/mtdna_blb/.nxf.log
vcf/mtdna_plp                            | PASSED | 6400350=completed output/vcf/mtdna_plp/.nxf.log
vcf/multiproject_classify                | PASSED | 6400351=completed output/vcf/multiproject_classify/.nxf.log
vcf/mvid                                 | PASSED | 6400352=completed output/vcf/mvid/.nxf.log
vcf/no_spliceai                          | PASSED | 6400353=completed output/vcf/no_spliceai/.nxf.log
vcf/str                                  | PASSED | 6400354=completed output/vcf/str/.nxf.log
vcf/trio                                 | PASSED | 6400355=completed output/vcf/trio/.nxf.log
vcf/vkgl_lb                              | PASSED | 6400356=completed output/vcf/vkgl_lb/.nxf.log
vcf/vkgl_lp                              | PASSED | 6400357=completed output/vcf/vkgl_lp/.nxf.log
vcf/vkgl_vus                             | PASSED | 6400358=completed output/vcf/vkgl_vus/.nxf.log
