### PR TITLE
Revert: End pos before Start pos in Green DB plugin

### DIFF
--- a/resources/vep/plugins/GREEN_DB.pm
+++ b/resources/vep/plugins/GREEN_DB.pm
@@ -69,7 +69,9 @@ sub get_scores {
   if($start <= $end){
     @data = @{$self->get_data($chr, $start, $end)};
   }else{
-    die "ERROR: Encountered an end position before the stop position";
+    #structural variant on the reverse strand
+    #This can occur because VEP determines end pos for small indels and takes strand into account.
+    @data = @{$self->get_data($chr, $end, $start)};
   }
 
   my $size = @data;


### PR DESCRIPTION
Before submitting this PR, please make sure:
- [ ] You have updated documentation for new/updated/removed features
- [ ] You have added tests
- [ ] You have manually run tests using `bash test/test.sh` and verified that all tests pass
