### PR TITLE
Prevent "argument list too long" when providing lots of fastq files

### DIFF
--- a/modules/fastq/templates/adaptive_sampling_filter_reads.sh
+++ b/modules/fastq/templates/adaptive_sampling_filter_reads.sh
@@ -41,6 +41,7 @@ esac
 
 concat() {
   # concatenate both compressed and uncompressed files
+  # use printf + xargs with -i {} to force per file concatenation to prevent "argument list too long" errors.
   printf '%s\0' !{fastqs} | xargs -0 -I {} sh -c 'zcat --force "$1"' _ {}
 }
 


### PR DESCRIPTION
Before submitting this PR, please make sure:
- [ ] You have updated documentation for new/updated/removed features
- [ ] You have added tests
- [ ] You have manually run tests using `bash test/test.sh` and verified that all tests pass

running tests ...
fastq/mtdna_fazzini_gs                   | PASSED | 6699101=completed output/fastq/mtdna_fazzini_gs/.nxf.log
fastq/nanopore_adaptive_sampling_adaptive01 | PASSED | 6699102=completed output/fastq/nanopore_adaptive_sampling_adaptive01/.nxf.log
fastq/nanopore_adaptive_sampling         | PASSED | 6699103=completed output/fastq/nanopore_adaptive_sampling/.nxf.log
fastq/nanopore                           | PASSED | 6699104=completed output/fastq/nanopore/.nxf.log
fastq/pacbio_hifi                        | PASSED | 6699105=completed output/fastq/pacbio_hifi/.nxf.log

