### PR TITLE
feat: add more categoricals to metadata

### DIFF
--- a/resources/field_metadata.json
+++ b/resources/field_metadata.json
@@ -296,13 +296,7 @@
             "Y_RNA": {
               "label": "Y RNA"
             },
-            "promoter_tss": {
-              "label": "promoter with TSS"
-            },
-            "distal_enhancer": {
-              "label": "distal enhancer"
-            },
-            "promoter": {
+                        "promoter": {
               "label": "promoter"
             },
             "promoter_flanking_region": {
@@ -311,21 +305,18 @@
             "enhancer": {
               "label": "enhancer"
             },
-            "ctcf_binding_site": {
+            "CTCF_binding_site": {
               "label": "CTCF binding site"
             },
             "open_chromatin_region": {
               "label": "open chromatin region"
             },
-            "tf_binding_site": {
+            "TF_binding_site": {
               "label": "transcription factor binding site"
             },
-            "transcribed_region": {
-              "label": "transcribed region"
-            },
-            "repressed_region": {
-              "label": "repressed or low-activity region"
-            }
+            "non_transcribed_region": {
+              "label": "non-transcribed region"
+                        }
           }
         },
         "CAPICE_CL": {

--- a/resources/field_metadata.json
+++ b/resources/field_metadata.json
@@ -109,6 +109,225 @@
           "numberCount": 1,
           "type": "FLOAT"
         },
+        "BIOTYPE": {
+          "label": "Biotype",
+          "description": "The Ensembl VEP Biotype.",
+          "numberType": "NUMBER",
+          "numberCount": 1,
+          "type": "CATEGORICAL",
+          "categories": {
+            "IG_C_gene": {
+              "label": "IG C gene"
+            },
+            "protein_coding_CDS_not_defined": {
+              "label": "protein coding CDS not defined"
+            },
+            "Mt_tRNA": {
+              "label": "Mt tRNA"
+            },
+            "TR_V_pseudogene": {
+              "label": "TR V pseudogene"
+            },
+            "other": {
+              "label": "other"
+            },
+            "vault_RNA": {
+              "label": "vault RNA"
+            },
+            "scRNA": {
+              "label": "scRNA"
+            },
+            "transcribed_pseudogene": {
+              "label": "transcribed pseudogene"
+            },
+            "lncRNA": {
+              "label": "lncRNA"
+            },
+            "IG_pseudogene": {
+              "label": "IG pseudogene"
+            },
+            "transcribed_unprocessed_pseudogene": {
+              "label": "transcribed unprocessed pseudogene"
+            },
+            "IG_V_pseudogene": {
+              "label": "IG V pseudogene"
+            },
+            "transcribed_unitary_pseudogene": {
+              "label": "transcribed unitary pseudogene"
+            },
+            "pseudogene": {
+              "label": "pseudogene"
+            },
+            "RNase_P_RNA": {
+              "label": "RNase P RNA"
+            },
+            "rRNA": {
+              "label": "rRNA"
+            },
+            "TR_V_gene": {
+              "label": "TR V gene"
+            },
+            "rRNA_pseudogene": {
+              "label": "rRNA pseudogene"
+            },
+            "TR_J_gene": {
+              "label": "TR J gene"
+            },
+            "aligned_transcript": {
+              "label": "aligned transcript"
+            },
+            "RNase_MRP_RNA": {
+              "label": "RNase MRP RNA"
+            },
+            "TR_D_gene": {
+              "label": "TR D gene"
+            },
+            "unprocessed_pseudogene": {
+              "label": "unprocessed pseudogene"
+            },
+            "IG_J_pseudogene": {
+              "label": "IG J pseudogene"
+            },
+            "processed_transcript": {
+              "label": "processed transcript"
+            },
+            "telomerase_RNA": {
+              "label": "telomerase RNA"
+            },
+            "protein_coding_LoF": {
+              "label": "protein coding LoF"
+            },
+            "ncRNA": {
+              "label": "ncRNA"
+            },
+            "TR_J_pseudogene": {
+              "label": "TR J pseudogene"
+            },
+            "retained_intron": {
+              "label": "retained intron"
+            },
+            "nonsense_mediated_decay": {
+              "label": "nonsense mediated decay"
+            },
+            "snRNA": {
+              "label": "snRNA"
+            },
+            "transcribed_processed_pseudogene": {
+              "label": "transcribed processed pseudogene"
+            },
+            "TR_C_gene": {
+              "label": "TR C gene"
+            },
+            "processed_pseudogene": {
+              "label": "processed pseudogene"
+            },
+            "translated_processed_pseudogene": {
+              "label": "translated processed pseudogene"
+            },
+            "miRNA": {
+              "label": "miRNA"
+            },
+            "protein_coding": {
+              "label": "protein coding"
+            },
+            "antisense_RNA": {
+              "label": "antisense RNA"
+            },
+            "IG_D_gene": {
+              "label": "IG D gene"
+            },
+            "LRG_gene": {
+              "label": "LRG gene"
+            },
+            "Mt_rRNA": {
+              "label": "Mt rRNA"
+            },
+            "mRNA": {
+              "label": "mRNA"
+            },
+            "ribozyme": {
+              "label": "ribozyme"
+            },
+            "unitary_pseudogene": {
+              "label": "unitary pseudogene"
+            },
+            "IG_J_gene": {
+              "label": "IG J gene"
+            },
+            "IG_V_gene": {
+              "label": "IG V gene"
+            },
+            "artifact": {
+              "label": "artifact"
+            },
+            "cdna_update": {
+              "label": "cdna update"
+            },
+            "ncRNA_pseudogene": {
+              "label": "ncRNA pseudogene"
+            },
+            "IG_C_pseudogene": {
+              "label": "IG C pseudogene"
+            },
+            "TEC": {
+              "label": "TEC"
+            },
+            "non_stop_decay": {
+              "label": "non stop decay"
+            },
+            "sRNA": {
+              "label": "sRNA"
+            },
+            "ccds_gene": {
+              "label": "ccds gene"
+            },
+            "tRNA": {
+              "label": "tRNA"
+            },
+            "snoRNA": {
+              "label": "snoRNA"
+            },
+            "scaRNA": {
+              "label": "scaRNA"
+            },
+            "misc_RNA": {
+              "label": "misc RNA"
+            },
+            "Y_RNA": {
+              "label": "Y RNA"
+            },
+            "promoter_tss": {
+              "label": "promoter with TSS"
+            },
+            "distal_enhancer": {
+              "label": "distal enhancer"
+            },
+            "promoter": {
+              "label": "promoter"
+            },
+            "promoter_flanking_region": {
+              "label": "promoter flanking region"
+            },
+            "enhancer": {
+              "label": "enhancer"
+            },
+            "ctcf_binding_site": {
+              "label": "CTCF binding site"
+            },
+            "open_chromatin_region": {
+              "label": "open chromatin region"
+            },
+            "tf_binding_site": {
+              "label": "transcription factor binding site"
+            },
+            "transcribed_region": {
+              "label": "transcribed region"
+            },
+            "repressed_region": {
+              "label": "repressed or low-activity region"
+            }
+          }
+        },
         "CAPICE_CL": {
           "label": "CAPICE",
           "description": "CAPICE classification",
@@ -280,7 +499,173 @@
           "description": "Effect(s) described as Sequence Ontology term(s)",
           "numberType": "OTHER",
           "separator": "&",
-          "type": "STRING"
+          "type": "CATEGORICAL",
+          "categories": {
+            "transcript_ablation": {
+              "label": "transcript ablation",
+              "description": "A feature ablation whereby the deleted region includes a transcript feature"
+            },
+            "splice_acceptor_variant": {
+              "label": "splice acceptor variant",
+              "description": "A splice variant that changes the 2 base region at the 3' end of an intron"
+            },
+            "splice_donor_variant": {
+              "label": "splice donor variant",
+              "description": "A splice variant that changes the 2 base region at the 5' end of an intron"
+            },
+            "stop_gained": {
+              "label": "stop gained",
+              "description": "A sequence variant whereby at least one base of a codon is changed, resulting in a premature stop codon, leading to a shortened transcript"
+            },
+            "frameshift_variant": {
+              "label": "frameshift variant",
+              "description": "A sequence variant which causes a disruption of the translational reading frame, because the number of nucleotides inserted or deleted is not a multiple of three"
+            },
+            "stop_lost": {
+              "label": "stop lost",
+              "description": "A sequence variant where at least one base of the terminator codon (stop) is changed, resulting in an elongated transcript"
+            },
+            "start_lost": {
+              "label": "start lost",
+              "description": "A codon variant that changes at least one base of the canonical start codon"
+            },
+            "transcript_amplification": {
+              "label": "transcript amplification",
+              "description": "A feature amplification of a region containing a transcript"
+            },
+            "feature_elongation": {
+              "label": "feature elongation",
+              "description": "A sequence variant that causes the extension of a genomic feature, with regard to the reference sequence"
+            },
+            "feature_truncation": {
+              "label": "feature truncation",
+              "description": "A sequence variant that causes the reduction of a genomic feature, with regard to the reference sequence"
+            },
+            "inframe_insertion": {
+              "label": "inframe insertion",
+              "description": "An inframe non synonymous variant that inserts bases into in the coding sequence"
+            },
+            "inframe_deletion": {
+              "label": "inframe deletion",
+              "description": "An inframe non synonymous variant that deletes bases from the coding sequence"
+            },
+            "missense_variant": {
+              "label": "missense variant",
+              "description": "A sequence variant, that changes one or more bases, resulting in a different amino acid sequence but where the length is preserved"
+            },
+            "protein_altering_variant": {
+              "label": "protein altering variant",
+              "description": "A sequence_variant which is predicted to change the protein encoded in the coding sequence"
+            },
+            "splice_donor_5th_base_variant": {
+              "label": "splice donor 5th base variant",
+              "description": "A sequence variant that causes a change at the 5th base pair after the start of the intron in the orientation of the transcript"
+            },
+            "splice_region_variant": {
+              "label": "splice region variant",
+              "description": "A sequence variant in which a change has occurred within the region of the splice site, either within 1-3 bases of the exon or 3-8 bases of the intron"
+            },
+            "splice_donor_region_variant": {
+              "label": "splice donor region variant",
+              "description": "A sequence variant that falls in the region between the 3rd and 6th base after splice junction (5' end of intron)"
+            },
+            "splice_polypyrimidine_tract_variant": {
+              "label": "splice polypyrimidine tract variant",
+              "description": "A sequence variant that falls in the polypyrimidine tract at 3' end of intron between 17 and 3 bases from the end (acceptor -3 to acceptor -17)"
+            },
+            "incomplete_terminal_codon_variant": {
+              "label": "incomplete terminal codon variant",
+              "description": "A sequence variant where at least one base of the final codon of an incompletely annotated transcript is changed"
+            },
+            "start_retained_variant": {
+              "label": "start retained variant",
+              "description": "A sequence variant where at least one base in the start codon is changed, but the start remains"
+            },
+            "stop_retained_variant": {
+              "label": "stop retained variant",
+              "description": "A sequence variant where at least one base in the terminator codon is changed, but the terminator remains"
+            },
+            "synonymous_variant": {
+              "label": "synonymous variant",
+              "description": "A sequence variant where there is no resulting change to the encoded amino acid"
+            },
+            "coding_sequence_variant": {
+              "label": "coding sequence variant",
+              "description": "A sequence variant that changes the coding sequence"
+            },
+            "mature_miRNA_variant": {
+              "label": "mature miRNA variant",
+              "description": "A transcript variant located with the sequence of the mature miRNA"
+            },
+            "5_prime_UTR_variant": {
+              "label": "5 prime UTR variant",
+              "description": "A UTR variant of the 5' UTR"
+            },
+            "3_prime_UTR_variant": {
+              "label": "3 prime UTR variant",
+              "description": "A UTR variant of the 3' UTR"
+            },
+            "non_coding_transcript_exon_variant": {
+              "label": "non coding transcript exon variant",
+              "description": "A sequence variant that changes non-coding exon sequence in a non-coding transcript"
+            },
+            "intron_variant": {
+              "label": "intron variant",
+              "description": "A transcript variant occurring within an intron"
+            },
+            "NMD_transcript_variant": {
+              "label": "NMD transcript variant",
+              "description": "A variant in a transcript that is the target of NMD"
+            },
+            "non_coding_transcript_variant": {
+              "label": "non coding transcript variant",
+              "description": "A transcript variant of a non coding RNA gene"
+            },
+            "coding_transcript_variant": {
+              "label": "coding transcript variant",
+              "description": "A transcript variant of a protein coding gene"
+            },
+            "upstream_gene_variant": {
+              "label": "upstream gene variant",
+              "description": "A sequence variant located 5' of a gene"
+            },
+            "downstream_gene_variant": {
+              "label": "downstream gene variant",
+              "description": "A sequence variant located 3' of a gene"
+            },
+            "TFBS_ablation": {
+              "label": "TFBS ablation",
+              "description": "A feature ablation whereby the deleted region includes a transcription factor binding site"
+            },
+            "TFBS_amplification": {
+              "label": "TFBS amplification",
+              "description": "A feature amplification of a region containing a transcription factor binding site"
+            },
+            "TF_binding_site_variant": {
+              "label": "TF binding site variant",
+              "description": "A sequence variant located within a transcription factor binding site"
+            },
+            "regulatory_region_ablation": {
+              "label": "regulatory region ablation",
+              "description": "A feature ablation whereby the deleted region includes a regulatory region"
+            },
+            "regulatory_region_amplification": {
+              "label": "regulatory region amplification",
+              "description": "A feature amplification of a region containing a regulatory region"
+            },
+            "regulatory_region_variant": {
+              "label": "regulatory region variant",
+              "description": "A sequence variant located within a regulatory region"
+            },
+            "intergenic_variant": {
+              "label": "intergenic variant",
+              "description": "A sequence variant located in the intergenic region, between genes"
+            },
+            "sequence_variant": {
+              "label": "sequence variant",
+              "description": "A sequence_variant is a non exact copy of a sequence_feature or genome exhibiting one or more sequence_alteration"
+            }
+          }
         },
         "Existing_variation": {
           "label": "Ex. var.",
@@ -688,6 +1073,19 @@
           "numberType": "NUMBER",
           "numberCount": 1,
           "type": "STRING"
+        },
+        "SYMBOL_SOURCE": {
+          "label": "Symbol Source",
+          "description": "The source of the symbol.",
+          "numberType": "NUMBER",
+          "numberCount": 1,
+          "type": "CATEGORICAL",
+          "categories": {
+            "EntrezGene": {
+              "label": "EntrezGene",
+              "description": "Symbol source Entrez Gene"
+            }
+          }
         },
         "VIPC": {
           "label": "VIP classification",


### PR DESCRIPTION
Note: breaks report until https://github.com/molgenis/vip-report-template/pull/375 is merged and the template is updated.

Before submitting this PR, please make sure:
- [ ] You have updated documentation for new/updated/removed features
- [ ] You have added tests
- [ ] You have manually run tests using `bash test/test.sh` and verified that all tests pass

vcf/aip                                  | PASSED | 6925668=completed output/vcf/aip/.nxf.log
vcf/chd7                                 | PASSED | 6925669=completed output/vcf/chd7/.nxf.log
vcf/corner_cases                         | PASSED | 6925670=completed output/vcf/corner_cases/.nxf.log
vcf/deb_register                         | PASSED | 6925671=completed output/vcf/deb_register/.nxf.log
vcf/empty_input                          | PASSED | 6925672=completed output/vcf/empty_input/.nxf.log
vcf/empty_output_filter_samples          | PASSED | 6925673=completed output/vcf/empty_output_filter_samples/.nxf.log
vcf/empty_output_filter                  | PASSED | 6925674=completed output/vcf/empty_output_filter/.nxf.log
vcf/filter_samples                       | PASSED | 6925675=completed output/vcf/filter_samples/.nxf.log
vcf/jvar_blb                             | PASSED | 6925676=completed output/vcf/jvar_blb/.nxf.log
vcf/jvar_plp                             | PASSED | 6925677=completed output/vcf/jvar_plp/.nxf.log
vcf/liftover                             | PASSED | 6925678=completed output/vcf/liftover/.nxf.log
vcf/mtdna_blb                            | PASSED | 6925679=completed output/vcf/mtdna_blb/.nxf.log
vcf/mtdna_plp                            | PASSED | 6925680=completed output/vcf/mtdna_plp/.nxf.log
vcf/multiproject_classify                | PASSED | 6925681=completed output/vcf/multiproject_classify/.nxf.log
vcf/mvid                                 | PASSED | 6925682=completed output/vcf/mvid/.nxf.log
vcf/no_spliceai                          | PASSED | 6925683=completed output/vcf/no_spliceai/.nxf.log
vcf/str                                  | PASSED | 6925684=completed output/vcf/str/.nxf.log
vcf/trio                                 | PASSED | 6925685=completed output/vcf/trio/.nxf.log
vcf/vkgl_lb                              | PASSED | 6925686=completed output/vcf/vkgl_lb/.nxf.log
vcf/vkgl_lp                              | PASSED | 6925687=completed output/vcf/vkgl_lp/.nxf.log
vcf/vkgl_vus                             | PASSED | 6925688=completed output/vcf/vkgl_vus/.nxf.log