### PR TITLE
feat: dynamic WES/WGS resource assignment

### DIFF
--- a/config/nxf.config
+++ b/config/nxf.config
@@ -16,24 +16,25 @@ env {
 }
 
 process {
-  memory = '4GB'
-  time = '4h'
+  // small safe defaults with explicit overrides
+  cpus   = 1
+  memory = 32.MB
+  time   = 15.m
 }
 
 profiles {
   local {
-    process.cpus = 4
     process.executor = 'local'
+    process.cpus = 4
   }
 
   slurm {
-    // many tasks process single or small groups of chromosomes e.g. resulting in 16 chunks for GRCh38
-    // optimize the number of cpus so that all chunks can be processed in parallel
-    process.cpus = 6
     process.executor = 'slurm'
     process.errorStrategy = { task.exitStatus in [9, 143, 137, 104, 134, 139, 247] ? 'retry' : 'finish' }
     process.maxErrors = '-1'
     process.maxRetries = 3
+
+    executor.$slurm.pollInterval = 1.s
   }
 }
 

--- a/config/nxf_call_cnv.config
+++ b/config/nxf_call_cnv.config
@@ -17,7 +17,15 @@ params {
 }
 
 process {
-  withLabel: 'spectre_call' {
-    memory = '8GB'
+	withLabel: 'spectre_call' {
+    cpus   = 4
+    memory = 4.GB
+    time   = 1.h
+  }
+
+  withLabel: 'vcf_merge_cnv' {
+    cpus   = 2
+    memory = 64.MB
+    time   = 15.m
   }
 }

--- a/config/nxf_call_mt.config
+++ b/config/nxf_call_mt.config
@@ -1,0 +1,34 @@
+includeConfig 'nxf.config'
+
+env {
+  CMD_MOSDEPTH="apptainer exec --no-mount home ${APPTAINER_CACHEDIR}/mosdepth-0.3.13.sif mosdepth"
+  CMD_SPECTRE="apptainer exec --no-mount home ${APPTAINER_CACHEDIR}/spectre-0.2.1+9058094.sif spectre"
+}
+
+params {
+	mt {
+		GRCh38 {
+			chrm_name = "chrM"
+		}
+	}
+}
+
+process {
+  withLabel: 'gatk_mutect2_mito' {
+    cpus   = 4
+    memory = 2.GB
+    time   = 30.m
+  }
+
+  withLabel: 'publish_mtdna_vcf' {
+    cpus   = 2
+    memory = { meta.project.sequencing_method == "WGS" ? 64.MB : 32.MB }
+    time   = 15.m
+  }
+
+  withLabel: 'vcf_merge_mtdnasnv' {
+    cpus   = 2
+    memory = 64.MB
+    time   = 15.m
+  }
+}

--- a/config/nxf_call_snv.config
+++ b/config/nxf_call_snv.config
@@ -81,22 +81,57 @@ params {
 }
 
 process {
+  withLabel: 'concat_snv_vcf' {
+    cpus   = 2
+    memory = 3.GB
+    time   = 15.m
+  }
+
   withLabel: 'deepvariant_call' {
-    time = '5h'
+    cpus   = 4
+    memory = { 4.GB * task.cpus }
+    time   = { meta.project.sequencing_method == "WGS" ? 12.h : 6.h }
   }
-  withLabel: 'deepvariant_call_duo|deepvariant_call_trio' {
-    time = '23h'
+
+  withLabel: 'deepvariant_call_duo' {
+    cpus   = 4
+    memory = { 8.GB * task.cpus }
+    time   = { meta.project.sequencing_method == "WGS" ? 24.h : 12.h }
   }
-  withLabel: 'deepvariant_concat_gvcf|deepvariant_concat_vcf' {
-    memory = '2GB'
-    time = '30m'
+
+  withLabel: 'deepvariant_call_trio' {
+    cpus   = 4
+    memory = { 8.GB * task.cpus }
+    time   = { meta.project.sequencing_method == "WGS" ? 24.h : 12.h }
   }
+
+  withLabel: 'deepvariant_concat_gvcfs' {
+    cpus   = 4
+    memory = 2.GB
+    time   = 30.m
+  }
+
+  withLabel: 'deepvariant_concat_vcfs' {
+    cpus   = 4
+    memory = 2.GB
+    time   = 30.m
+  }
+
   withLabel: 'deepvariant_joint_call' {
-    memory = '2GB'
-    time = '30m'
+    cpus   = 2
+    memory = 2.GB
+    time   = 15.m
   }
+
+  withLabel: 'publish_gvcf' {
+    cpus   = 2
+    memory = 3.GB
+    time   = 15.m
+  }
+
   withLabel: 'whatshap' {
-    memory = '16GB'
-    time = '23h'
+    cpus   = 2
+    memory = 2.GB
+    time   = 1.h
   }
 }

--- a/config/nxf_call_str.config
+++ b/config/nxf_call_str.config
@@ -43,8 +43,20 @@ params {
 
 process {
   withLabel: 'expansionhunter_call' {
-    cpus = 4
-    memory = '16GB'
-    time = '5h'
+    cpus   = 4
+    memory = 16.GB
+    time   = 5.h
+  }
+
+  withLabel: 'straglr_call' {
+    cpus   = 1
+    memory = 1.GB
+    time   = 15.m
+  }
+
+  withLabel: 'vcf_merge_str' {
+    cpus   = 2
+    memory = 64.MB
+    time   = 15.m
   }
 }

--- a/config/nxf_call_sv.config
+++ b/config/nxf_call_sv.config
@@ -58,14 +58,21 @@ params {
 }
 
 process {
-  withLabel: 'manta_joint_call' {
-    cpus = 4
-    memory = '8GB'
-    time = '5h'
-  }
   withLabel: 'cutesv_call' {
     cpus = 4
-    memory = '8GB'
-    time = '5h'
+    memory = 8.GB
+    time = 5.h
+  }
+
+  withLabel: 'manta_joint_call' {
+    cpus = 2
+    memory = { meta.project.sequencing_method == "WGS" ? 8.GB : 2.GB }
+    time = { meta.project.sequencing_method == "WGS" ? 5.h : 2.h }
+  }
+
+  withLabel: 'vcf_merge_sv' {
+    cpus   = 2
+    memory = 64.MB
+    time   = 15.m
   }
 }

--- a/config/nxf_cram.config
+++ b/config/nxf_cram.config
@@ -1,5 +1,6 @@
 includeConfig 'nxf_vcf.config'
 includeConfig 'nxf_call_cnv.config'
+includeConfig 'nxf_call_mt.config'
 includeConfig 'nxf_call_snv.config'
 includeConfig 'nxf_call_str.config'
 includeConfig 'nxf_call_sv.config'
@@ -22,32 +23,25 @@ params {
         default_bed_gene = "${VIP_DIR_DATA}/resources/GRCh38/default_gene_20250303.bed"
       }
     }
-
-    mitochondria {
-      GRCh38 {
-        chrm_name = "chrM"
-      }
-    }
   }
 }
 
 process {
+  withLabel: 'concat_vcf' {
+    cpus   = 2
+    memory = 3.GB
+    time   = 15.m
+  }
+
   withLabel: 'coverage' {
-		cpus = 1
-		// see https://github.com/brentp/mosdepth/issues/245
-    memory = '16GB'
+    cpus   = 1
+    memory = 4.GB // see https://github.com/brentp/mosdepth/issues/245
+    time   = { meta.project.sequencing_method == "WGS" ? 30.m : 15.m }
   }
+
   withLabel: 'publish_vcf' {
-    memory = '100MB'
-    time = '30m'
-  }
-  withLabel: 'gatk_mutect2_mito' {
-    cpus = 4
-    memory = '6GB'
-    time = '1h'
-  }
-  withLabel: 'publish_mtdna_vcf' {
-    memory = '100MB'
-    time = '30m'
+    cpus   = 2
+    memory = { meta.project.sequencing_method == "WGS" ? 64.MB : 32.MB }
+    time   = 15.m
   }
 }

--- a/config/nxf_fastq.config
+++ b/config/nxf_fastq.config
@@ -7,27 +7,29 @@ env {
 }
 
 process {
-	withLabel: 'filter_reads' {
-		cpus = 1
-  }
-
   withLabel: 'fastp' {
-    cpus = 8
-    memory = '16GB'
-    time = '30m'
+    cpus   = 4
+    memory = { meta.project.sequencing_method == "WGS" ? 20.GB : 2.GB }
+    time   = { meta.project.sequencing_method == "WGS" ? 2.h : 30.m }
   }
 
-  withLabel: 'minimap2_align|minimap2_align_paired_end' {
-    cpus = 8
-    memory = '32GB'
-    time = '23h'
+  withLabel: 'filter_reads' {
+    cpus   = 1
+    memory = 4.GB
+    time   = 4.h
   }
 
-  withLabel: 'merge_cram' {
-		cpus = 8
-		memory = '16GB'
-		time = '23h'
-	}
+  withLabel: 'minimap2_align' {
+    cpus   = { meta.project.sequencing_method == "WGS" ? 16 : 8 }
+    memory = { meta.project.sequencing_method == "WGS" ? 32.GB : 16.GB }
+    time   = { meta.project.sequencing_method == "WGS" ? 24.h : 1.h }
+  }
+
+  withLabel: 'minimap2_align_paired_end' {
+    cpus   = { meta.project.sequencing_method == "WGS" ? 16 : 8 }
+    memory = { meta.project.sequencing_method == "WGS" ? 32.GB : 16.GB }
+    time   = { meta.project.sequencing_method == "WGS" ? 24.h : 1.h }
+  }
 }
 
 params {

--- a/config/nxf_gvcf.config
+++ b/config/nxf_gvcf.config
@@ -1,13 +1,28 @@
 includeConfig 'nxf_vcf.config'
 
 process {
-  withLabel: 'gvcf_validate' {
-    memory = '100MB'
-    time = '30m'
+  withLabel: 'gvcf_liftover' {
+    cpus   = 2
+    memory = 4.GB
+    time   = 15.m
   }
+
   withLabel: 'gvcf_merge' {
-    memory = '2GB'
-    time = '30m'
+    cpus   = 4
+    memory = 2.GB
+    time   = 30.m
+  }
+
+  withLabel: 'gvcf_merge_publish' {
+    cpus   = 2
+    memory = 64.MB
+    time   = 15.m
+  }
+
+  withLabel: 'gvcf_validate' {
+    cpus = { meta.project.sequencing_method == "WGS" ? 3 : 2 }
+    memory = 100.MB
+    time   = 30.m
   }
 }
 

--- a/config/nxf_vcf.config
+++ b/config/nxf_vcf.config
@@ -16,28 +16,118 @@ env {
 }
 
 process {
-  withLabel: 'vcf_validate' {
-    memory = '100MB'
-    time = '30m'
+  withLabel: 'bed_filter' {
+    cpus   = 2
+    memory = { meta.project.sequencing_method == "WGS" ? 64.MB : 32.MB }
+    time   = 15.m
   }
 
-  withLabel: 'vcf_split' {
-    memory = '100MB'
-    time = '30m'
+  withLabel: 'cram_validate' {
+    cpus   = { meta.project.sequencing_method == "WGS" ? 3 : 2 }
+    memory = { meta.project.sequencing_method == "WGS" ? 1.GB : 512.MB }
+    time   = { meta.project.sequencing_method == "WGS" ? 1.h : 15.m }
+  }
+
+  withLabel: 'gado' {
+    cpus   = 2
+    memory = 1.GB
+    time   = 15.m
   }
 
   withLabel:'vcf_annotate' {
     cpus = 4
-    memory = '8GB'
-    time = '4h'
+    memory = { meta.project.sequencing_method == "WGS" ? 8.GB : 4.GB }
+    time = { meta.project.sequencing_method == "WGS" ? 4.h : 1.h }
   }
 
-  withLabel:'vcf_classify|vcf_classify_samples|vcf_inheritance' {
-    memory = '2GB'
+  withLabel: 'vcf_annotate_publish' {
+    cpus   = 2
+    memory = 64.MB
+    time   = 15.m
+  }
+
+  withLabel: 'vcf_classify_publish' {
+    cpus   = 2
+    memory = 64.MB
+    time   = 15.m
+  }
+
+  withLabel: 'vcf_classify' {
+    cpus   = 2
+    memory = { meta.project.sequencing_method == "WGS" ? 2.GB : 1.GB }
+    time   = 15.m
+  }
+
+  withLabel: 'vcf_classify_samples' {
+    cpus   = 2
+    memory = { meta.project.sequencing_method == "WGS" ? 512.MB : 256.MB }
+    time   = 15.m
+  }
+
+  withLabel: 'vcf_classify_samples_publish' {
+    cpus   = 2
+    memory = 64.MB
+    time   = 15.m
+  }
+
+  withLabel: 'vcf_concat' {
+    cpus   = 2
+    memory = { meta.project.sequencing_method == "WGS" ? 64.MB : 32.MB }
+    time   = 15.m
+  }
+
+  withLabel: 'vcf_filter' {
+    cpus   = 2
+    memory = { meta.project.sequencing_method == "WGS" ? 256.MB : 128.MB }
+    time   = 15.m
+  }
+
+  withLabel: 'vcf_filter_samples' {
+    cpus   = 2
+    memory = { meta.project.sequencing_method == "WGS" ? 64.MB : 32.MB }
+    time   = 15.m
+  }
+
+  withLabel: 'vcf_inheritance' {
+    cpus   = 2
+    memory = { meta.project.sequencing_method == "WGS" ? 2.GB : 1.GB }
+    time   = 15.m
+  }
+
+  withLabel: 'vcf_liftover' {
+    cpus   = 2
+    memory = 4.GB
+    time   = 15.m
+  }
+
+  withLabel: 'vcf_normalize' {
+    cpus   = { meta.project.sequencing_method == "WGS" ? 4 : 2 } 
+    memory = { meta.project.sequencing_method == "WGS" ? 512.MB : 256.MB }
+    time   = 15.m
   }
 
   withLabel: 'vcf_report' {
-    memory = '6GB'
+    cpus   = 2
+    memory = { meta.project.sequencing_method == "WGS" ? 8.GB : 4.GB }
+    time   = { meta.project.sequencing_method == "WGS" ? 30.m : 15.m }
+  }
+
+  withLabel: 'vcf_slice' {
+    cpus   = 4
+    memory = 2.GB
+    time   = 15.m
+  }
+
+  withLabel: 'vcf_split' {
+    cpus   = 2
+    memory = 64.MB
+    time   = 15.m
+  }
+
+  withLabel: 'vcf_validate' {
+    cpus = { meta.project.sequencing_method == "WGS" ? 3 : 2 }
+    memory = 100.MB
+    time = 30.m
   }
 }
 

--- a/docs/usage/config.md
+++ b/docs/usage/config.md
@@ -205,71 +205,80 @@ Cloud.
 
 ## Process
 
-By default, each process gets assigned `4 cpus`, `8GB of memory` and a `max runtime of 4 hours`. Depending on your
-system specifications and your analysis you might need to use updated values. For information on how to update process
-configuration see the [Nextflow documentation](https://www.nextflow.io/docs/latest/config.html#scope-process).
-The following sections list all processes and their non-default configuration.
+Depending on your system specifications and your analysis you might need to use updated resource values. For information
+on how to update process configuration see
+the [Nextflow documentation](https://www.nextflow.io/docs/latest/config.html#scope-process). The following sections list
+all processes and their non-default configuration.
 
 ### FASTQ
 
-| process label             | configuration                   |
-|---------------------------|---------------------------------|
-| concat_fastq              | *default*                       |
-| concat_fastq_paired_end   | *default*                       |
-| minimap2_align            | cpus=8 memory='16GB' time='23h' |
-| minimap2_align_paired_end | cpus=8 memory='16GB' time='23h' |
+| Process label             | CPUs (WES / WGS) | Memory (WES / WGS) | Time (WES / WGS) |
+|---------------------------|------------------|--------------------|------------------|
+| fastp                     | 4                | 20 / 2 GB          | 2 h / 30 m       |
+| filter_reads              | 1                | 4 GB               | 4 h              |
+| minimap2_align            | 8 / 16           | 16 / 32 GB         | 1 h / 24 h       |
+| minimap2_align_paired_end | 8 / 16           | 16 / 32 GB         | 1 h / 24 h       |
 
 ### CRAM
 
-| process label           | configuration                                 |
-|-------------------------|-----------------------------------------------|
-| concat_vcf              | *default*                                     |
-| coverage                | cpus=1 memory='16GB' time=*default*           |
-| cram_validate           | *default*                                     |
-| cutesv_call             | cpus=4 memory='8GB' time='5h'                 |
-| deepvariant_call        | cpus=*default* memory='2GB * cpus' time='5h'  |
-| deepvariant_call_duo    | cpus=*default* memory='6GB * cpus' time='23h' |
-| deepvariant_call_trio   | cpus=*default* memory='6GB * cpus' time='23h' |
-| deepvariant_concat_gvcf | cpus=*default* memory='2GB' time='30m'        |
-| deepvariant_concat_vcf  | cpus=*default* memory='2GB' time='30m'        |
-| deepvariant_joint_call  | cpus=*default* memory='2GB' time='30m'        |
-| expansionhunter_call    | cpus=4 memory='16GB' time='5h'                |
-| manta_joint_call        | cpus=4 memory='8GB' time='5h'                 |
-| publish_vcf             | memory='100MB' time='30m'                     |
-| spectre_call            | cpus=*default* memory='4GB' time=*default*    |
-| straglr_call            | *default*                                     |
-| vcf_merge_str           | *default*                                     |
-| vcf_merge_sv            | *default*                                     |
-| whatshap                | cpus=*default* memory=*default* time='23h'    |
+| Process label            | CPUs (WES / WGS) | Memory (WES / WGS) | Time (WES / WGS) |
+|--------------------------|------------------|--------------------|------------------|
+| concat_snv_vcf           | 2                | 3 GB               | 15 m             |
+| concat_vcf               | 2                | 3 GB               | 15 m             |
+| coverage                 | 1                | 4 GB               | 15 m / 30 m      |
+| cutesv_call              | 4                | 8 GB               | 5 h              |
+| deepvariant_call         | 4                | 16 GB              | 6 h / 12 h       |
+| deepvariant_call_duo     | 4                | 32 GB              | 12 h / 24 h      |
+| deepvariant_call_trio    | 4                | 32 GB              | 12 h / 24 h      |
+| deepvariant_concat_gvcfs | 4                | 2 GB               | 30 m             |
+| deepvariant_concat_vcfs  | 2                | 64 MB              | 15 m             |
+| deepvariant_joint_call   | 2                | 2 GB               | 15 m             |
+| gatk_mutect2_mito        | 4                | 2 GB               | 30 m             |
+| manta_joint_call         | 4                | 2 / 8 GB           | 2 / 5 h          |
+| publish_gvcf             | 2                | 3 GB               | 15 m             |
+| publish_vcf              | 2                | 32 / 64 MB         | 15 m             |
+| publish_mtdna_vcf        | 2                | 32 / 64 MB         | 15 m             |
+| spectre_call             | 4                | 4 GB               | 1 h              |
+| straglr_call             | 1                | 1 GB               | 15 m             |
+| vcf_merge_cnv            | 2                | 64 MB              | 15 m             |
+| vcf_merge_mtdnasnv       | 2                | 64 MB              | 15 m             |
+| vcf_merge_str            | 2                | 64 MB              | 15 m             |
+| vcf_merge_sv             | 2                | 64 MB              | 15 m             |
+
+| whatshap | 2 | 2 GB | 1 h |
 
 ### gVCF
 
-| process label | configuration             |
-|---------------|---------------------------|
-| gvcf_liftover | *default*                 |
-| gvcf_validate | memory='100MB' time='30m' |
-| gvcf_merge    | memory='2GB' time='30m'   |
+| Process label      | CPUs (WES / WGS) | Memory (WES / WGS) | Time (WES / WGS) |
+|--------------------|------------------|--------------------|------------------|
+| gvcf_liftover      | 2                | 4 GB               | 15 m             |
+| gvcf_merge         | 4                | 2 GB               | 30 m             |
+| gvcf_merge_publish | 2                | 64 MB              | 15 m             |
+| gvcf_validate      | 2 / 3            | 100 MB             | 30 m             |
 
 ### VCF
 
-| process label                | configuration                 |
-|------------------------------|-------------------------------|
-| vcf_annotate                 | cpus=4 memory='8GB' time='4h' |
-| vcf_annotate_publish         | *default*                     |
-| vcf_classify                 | memory = '2GB'                |
-| vcf_classify_publish         | *default*                     |
-| vcf_classify_samples         | memory = '2GB'                |
-| vcf_classify_samples_publish | *default*                     |
-| vcf_concat                   | *default*                     |
-| vcf_filter                   | *default*                     |
-| vcf_filter_samples           | *default*                     |
-| vcf_inheritance              | memory = '2GB'                |
-| vcf_liftover                 | *default*                     |
-| vcf_normalize                | *default*                     |
-| vcf_report                   | memory = '4GB'                |
-| vcf_slice                    | *default*                     |
-| vcf_split                    | memory='100MB' time='30m'     |
-| vcf_validate                 | memory='100MB' time='30m'     |
+| Process label                | CPUs (WES / WGS) | Memory (WES / WGS) | Time (WES / WGS) |
+|------------------------------|------------------|--------------------|------------------|
+| bed_filter                   | 2                | 32 / 64 MB         | 15 m             |
+| cram_validate                | 2 / 3            | 512 MB / 1 GB      | 1 h / 30 m       |
+| gado                         | 2                | 1 GB               | 15 m             |
+| vcf_annotate                 | 4                | 4 / 8 GB           | 1 h / 4 h        |
+| vcf_annotate_publish         | 2                | 64 MB              | 15 m             |
+| vcf_classify_publish         | 2                | 64 MB              | 15 m             |
+| vcf_classify                 | 2                | 1 / 2 GB           | 15 m             |
+| vcf_classify_samples         | 2                | 256 / 512 MB       | 15 m             |
+| vcf_classify_samples_publish | 2                | 64 MB              | 15 m             |
+| vcf_concat                   | 2                | 32 / 64 MB         | 15 m             |
+| vcf_filter                   | 2                | 128 / 256 MB       | 15 m             |
+| vcf_filter_samples           | 2                | 32 / 64 MB         | 15 m             |
+| vcf_inheritance              | 2                | 1 / 2 GB           | 15 m             |
+| vcf_liftover                 | 2                | 4 GB               | 15 m             |
+| vcf_normalize                | 2 / 4            | 256 / 512 MB       | 15 m             |
+| vcf_report                   | 2                | 4 / 8 GB           | 15 m / 30 m      |
+| vcf_slice                    | 4                | 2 GB               | 15 m             |
+| vcf_split                    | 2                | 64 MB              | 15 m             |
+| vcf_validate                 | 2 / 3            | 100 MB             | 30 m             |
 
 ## Environment
 

--- a/modules/cram/deepvariant.nf
+++ b/modules/cram/deepvariant.nf
@@ -1,8 +1,6 @@
 process call {
   label 'deepvariant_call'
 
-  memory { 2.GB * task.cpus }
-
   input:
     tuple val(meta), path(cram), path(cramCrai)
 
@@ -14,7 +12,7 @@ process call {
     reference = refSeqPath.substring(0, refSeqPath.lastIndexOf('.'))
     haploidContigs = params.snv[meta.project.assembly].reference.haploidContigs
     parRegionsBed = params.snv[meta.project.assembly].reference.parRegionsBed
-    chrmName = params.cram.mitochondria[meta.project.assembly].chrm_name
+    chrmName = params.mt[meta.project.assembly].chrm_name
     bed="regions_chunk_${meta.chunk.index}.bed"
     bedContent = meta.chunk.regions.findAll{ region -> "${region.chrom}" != "${chrmName}" }.collect { region -> "${region.chrom}\t${region.chromStart}\t${region.chromEnd}" }.join("\n")
     sampleName = "${meta.sample.individual_id}"
@@ -43,8 +41,6 @@ process call {
 process call_duo {
   label 'deepvariant_call_duo'
 
-  memory { 6.GB * task.cpus }
-
   input:
     tuple val(meta), path(cramChild), path(cramCraiChild),
                      path(cramParent), path(cramCraiParent)
@@ -58,7 +54,7 @@ process call_duo {
     reference = refSeqPath.substring(0, refSeqPath.lastIndexOf('.'))
     haploidContigs = params.snv[meta.project.assembly].reference.haploidContigs
     parRegionsBed = params.snv[meta.project.assembly].reference.parRegionsBed
-    chrmName = params.cram.mitochondria[meta.project.assembly].chrm_name
+    chrmName = params.mt[meta.project.assembly].chrm_name
     bed="regions_chunk_${meta.chunk.index}.bed"
     bedContent = meta.chunk.regions.findAll{ region -> "${region.chrom}" != "${chrmName}" }.collect { region -> "${region.chrom}\t${region.chromStart}\t${region.chromEnd}" }.join("\n")
 
@@ -138,7 +134,7 @@ process call_trio {
     reference = refSeqPath.substring(0, refSeqPath.lastIndexOf('.'))
     haploidContigs = params.snv[meta.project.assembly].reference.haploidContigs
     parRegionsBed = params.snv[meta.project.assembly].reference.parRegionsBed
-    chrmName = params.cram.mitochondria[meta.project.assembly].chrm_name
+    chrmName = params.mt[meta.project.assembly].chrm_name
     bed="regions_chunk_${meta.chunk.index}.bed"
     bedContent = meta.chunk.regions.findAll{ region -> "${region.chrom}" != "${chrmName}" }.collect { region -> "${region.chrom}\t${region.chromStart}\t${region.chromEnd}" }.join("\n")
 

--- a/modules/cram/gatk.nf
+++ b/modules/cram/gatk.nf
@@ -10,7 +10,7 @@ process mutect2_mito {
   shell:
     refSeqPath = params[meta.project.assembly].reference.fasta
     reference = refSeqPath.substring(0, refSeqPath.lastIndexOf('.'))
-    chrmName = params.cram.mitochondria[meta.project.assembly].chrm_name
+    chrmName = params.mt[meta.project.assembly].chrm_name
 
     vcfOut = "${meta.project.id}_${meta.sample.family_id}_${meta.sample.individual_id}_chrm_snv.vcf.gz"
     vcfOutIndex = "${vcfOut}.csi"

--- a/modules/cram/split_cram_chrm.nf
+++ b/modules/cram/split_cram_chrm.nf
@@ -10,7 +10,7 @@ process split_cram_chrm {
   shell:
     refSeqPath = params[meta.project.assembly].reference.fasta
     reference = refSeqPath.substring(0, refSeqPath.lastIndexOf('.'))
-    chrmName = params.cram.mitochondria[meta.project.assembly].chrm_name
+    chrmName = params.mt[meta.project.assembly].chrm_name
 
     chrmCramOut = "${meta.project.id}_${meta.sample.family_id}_${meta.sample.individual_id}_chrm.cram"
     chrmCramOutIndex = "${chrmCramOut}.crai"

--- a/modules/cram/templates/concat_snv_vcf.sh
+++ b/modules/cram/templates/concat_snv_vcf.sh
@@ -19,7 +19,7 @@ concat () {
 }
 
 bcftools_sort () {
-  ${CMD_BCFTOOLS} norm --do-not-normalize --rm-dup exact --no-version --threads "!{task.cpus}" "unsorted_!{vcfOut}" | ${CMD_BCFTOOLS} sort --temp-dir . --max-mem "!{task.memory.toGiga() - 1}G" --output-type z --output "!{vcfOut}"
+  ${CMD_BCFTOOLS} norm --do-not-normalize --rm-dup exact --no-version --threads "!{task.cpus}" "unsorted_!{vcfOut}" | ${CMD_BCFTOOLS} sort --temp-dir . --max-mem "!{(task.memory.toMega() * 0.75).intValue()}M" --output-type z --output "!{vcfOut}"
 }
 
 index () {

--- a/modules/cram/templates/concat_vcf.sh
+++ b/modules/cram/templates/concat_vcf.sh
@@ -19,7 +19,7 @@ concat () {
 }
 
 bcftools_sort () {
-  ${CMD_BCFTOOLS} norm --do-not-normalize --rm-dup exact --no-version --threads "!{task.cpus}" "unsorted_!{vcfOut}" | ${CMD_BCFTOOLS} sort --temp-dir . --max-mem "!{task.memory.toGiga() - 1}G" --output-type z --output "!{vcfOut}"
+  ${CMD_BCFTOOLS} norm --do-not-normalize --rm-dup exact --no-version --threads "!{task.cpus}" "unsorted_!{vcfOut}" | ${CMD_BCFTOOLS} sort --temp-dir . --max-mem "!{(task.memory.toMega() * 0.75).intValue()}M" --output-type z --output "!{vcfOut}"
 }
 
 index () {
@@ -38,7 +38,7 @@ order_samples () {
   done
 }
 
-main() {  
+main() {
   order_samples
   concat
   bcftools_sort

--- a/modules/cram/templates/mutect2_mito.sh
+++ b/modules/cram/templates/mutect2_mito.sh
@@ -1,8 +1,8 @@
 mutect2 () {
     local mutect_args=()
     mutect_args+=("-Djava.io.tmpdir=${TMPDIR}")
-    mutect_args+=("-XX:ParallelGCThreads=2")
-    mutect_args+=("-Xmx!{task.memory.toMega() - 512}m")
+    mutect_args+=("-XX:ParallelGCThreads=!{Math.max(task.cpus - 4, 1)}")
+    mutect_args+=("-Xmx!{(task.memory.toMega() * 0.75).intValue()}m")
     mutect_args+=("-jar" "/opt/gatk/lib/gatk.jar")
     mutect_args+=("Mutect2")
     mutect_args+=("-R" "!{reference}")

--- a/modules/cram/templates/validate.sh
+++ b/modules/cram/templates/validate.sh
@@ -36,7 +36,7 @@ view () {
   view_args+=("--bam")
   view_args+=("--output" "!{cramOut}")
   view_args+=("--no-PG")                     # do not add a @PG line to the header of the output file
-  view_args+=("--threads" "!{task.cpus}")
+  view_args+=("--threads" "!{task.cpus - 1}")
   view_args+=("-")
 
   ${CMD_SAMTOOLS} reheader "${reheader_args[@]}" | ${CMD_SAMTOOLS} view "${view_args[@]}"

--- a/modules/vcf/templates/classify.sh
+++ b/modules/vcf/templates/classify.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 classify () {
   local args=()
   args+=("-Djava.io.tmpdir=\"${TMPDIR}\"")
-  args+=("-XX:ParallelGCThreads=2")
-  args+=("-Xmx!{task.memory.toMega() - 512}m")
+  args+=("-XX:ParallelGCThreads=!{task.cpus - 1}")
+  args+=("-Xmx!{(task.memory.toMega() * 0.75).intValue()}m")
   args+=("-jar" "/opt/vcf-decision-tree/lib/vcf-decision-tree.jar")
   args+=("--input" "!{vcf}_replaced.vcf.gz")
   args+=("--metadata" "!{metadata}")

--- a/modules/vcf/templates/classify_samples.sh
+++ b/modules/vcf/templates/classify_samples.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 classify_samples() {
   local args=()
   args+=("-Djava.io.tmpdir=\"${TMPDIR}\"")
-  args+=("-XX:ParallelGCThreads=2")
-  args+=("-Xmx!{task.memory.toMega() - 512}m")
+  args+=("-XX:ParallelGCThreads=!{task.cpus - 1}")
+  args+=("-Xmx!{(task.memory.toMega() * 0.75).intValue()}m")
   args+=("-jar" "/opt/vcf-decision-tree/lib/vcf-decision-tree.jar")
   args+=("--input" "!{vcf}_replaced.vcf.gz")
   args+=("--metadata" "!{metadata}")

--- a/modules/vcf/templates/gado.sh
+++ b/modules/vcf/templates/gado.sh
@@ -7,7 +7,8 @@ gado_process() {
 
   local args=()
   args+=("-Djava.io.tmpdir=\"${TMPDIR}\"")
-  args+=("-XX:ParallelGCThreads=2")
+  args+=("-XX:ParallelGCThreads=!{task.cpus - 1}")
+  args+=("-Xmx!{(task.memory.toMega() * 0.75).intValue()}m")
   args+=("-Xmx!{task.memory.toMega() - 512}m")
   args+=("-jar" "/opt/gado/lib/GADO.jar")
   args+=("--mode" "PROCESS")
@@ -22,8 +23,8 @@ gado_process() {
 gado_prioritize() {
   local args=()
   args+=("-Djava.io.tmpdir=\"${TMPDIR}\"")
-  args+=("-XX:ParallelGCThreads=2")
-  args+=("-Xmx!{task.memory.toMega() - 512}m")
+  args+=("-XX:ParallelGCThreads=!{task.cpus - 1}")
+  args+=("-Xmx!{(task.memory.toMega() * 0.75).intValue()}m")
   args+=("-jar" "/opt/gado/lib/GADO.jar")
   args+=("--mode" "PRIORITIZE")
   args+=("--output" "./gado")

--- a/modules/vcf/templates/inheritance.sh
+++ b/modules/vcf/templates/inheritance.sh
@@ -8,8 +8,8 @@ create_ped () {
 inheritance () {
   local args=()
   args+=("-Djava.io.tmpdir=\"${TMPDIR}\"")
-  args+=("-XX:ParallelGCThreads=2")
-  args+=("-Xmx!{task.memory.toMega() - 512}m")
+  args+=("-XX:ParallelGCThreads=!{task.cpus - 1}")
+  args+=("-Xmx!{(task.memory.toMega() * 0.75).intValue()}m")
   args+=("-jar" "/opt/vcf-inheritance-matcher/lib/vcf-inheritance-matcher.jar")
   args+=("--input" "!{vcf}_replaced.vcf.gz")
   args+=("--output" "!{vcfOut}_replaced.vcf.gz")

--- a/modules/vcf/templates/liftover.sh
+++ b/modules/vcf/templates/liftover.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 liftover() {
   local args=()
   args+=("-Djava.io.tmpdir=\"${TMPDIR}\"")
-  args+=("-XX:ParallelGCThreads=2")
-  args+=("-Xmx!{task.memory.toMega() - 512}m")
+  args+=("-XX:ParallelGCThreads=!{task.cpus - 1}")
+  args+=("-Xmx!{(task.memory.toMega() * 0.75).intValue()}m")
   args+=("-jar" "/opt/picard/lib/picard.jar")
   args+=("LiftoverVcf")
   args+=("--CHAIN" "!{chain}")

--- a/modules/vcf/templates/normalize.sh
+++ b/modules/vcf/templates/normalize.sh
@@ -18,7 +18,7 @@ normalize () {
 
 sort () {
   # sort since order can change due to normalization, cant pipe due to concurrent modification cause by 'norm' multithreading
-  ${CMD_BCFTOOLS} sort --temp-dir . --max-mem "!{task.memory.toGiga() - 1}G" --output-type z --output "!{vcfOut}" "unsorted_!{vcfOut}"
+  ${CMD_BCFTOOLS} sort --temp-dir . --max-mem "!{(task.memory.toMega() * 0.75).intValue()}M" --output-type z --output "!{vcfOut}" "unsorted_!{vcfOut}"
 }
 
 index () {

--- a/modules/vcf/templates/report.sh
+++ b/modules/vcf/templates/report.sh
@@ -35,8 +35,8 @@ report() {
   
   local args=()
   args+=("-Djava.io.tmpdir=${TMPDIR}")
-  args+=("-XX:ParallelGCThreads=2")
-  args+=("-Xmx!{task.memory.toMega() - 512}m")
+  args+=("-XX:ParallelGCThreads=!{task.cpus - 1}")
+  args+=("-Xmx!{(task.memory.toMega() * 0.75).intValue()}m")
   args+=("-jar" "/opt/vcf-report/lib/vcf-report.jar")
   args+=("--input" "!{vcfOut}")
   args+=("--metadata" "!{metadata}")


### PR DESCRIPTION
```
running tests ...
cram/complex                             | PASSED | 4829224=completed vip/feat_wes_wgs_config/test/output/cram/complex/.nxf.log
cram/multiproject                        | PASSED | 4829225=completed vip/feat_wes_wgs_config/test/output/cram/multiproject/.nxf.log
cram/nanopore_duo                        | PASSED | 4829226=completed vip/feat_wes_wgs_config/test/output/cram/nanopore_duo/.nxf.log
cram/nanopore                            | PASSED | 4829227=completed vip/feat_wes_wgs_config/test/output/cram/nanopore/.nxf.log
cram/single                              | PASSED | 4829228=completed vip/feat_wes_wgs_config/test/output/cram/single/.nxf.log
cram/trio                                | PASSED | 4829229=completed vip/feat_wes_wgs_config/test/output/cram/trio/.nxf.log
fastq/mtdna_fazzini_gs                   | PASSED | 4829230=completed vip/feat_wes_wgs_config/test/output/fastq/mtdna_fazzini_gs/.nxf.log
fastq/nanopore_adaptive_sampling_new     | PASSED | 4829231=completed vip/feat_wes_wgs_config/test/output/fastq/nanopore_adaptive_sampling_new/.nxf.log
fastq/nanopore_adaptive_sampling_old     | PASSED | 4829232=completed vip/feat_wes_wgs_config/test/output/fastq/nanopore_adaptive_sampling_old/.nxf.log
fastq/nanopore                           | PASSED | 4829233=completed vip/feat_wes_wgs_config/test/output/fastq/nanopore/.nxf.log
fastq/pacbio_hifi                        | PASSED | 4829234=completed vip/feat_wes_wgs_config/test/output/fastq/pacbio_hifi/.nxf.log
giab/AshkenazimTrio_illumina_wes         | PASSED | 4829235=completed vip/feat_wes_wgs_config/test/output/giab/AshkenazimTrio_illumina_wes/.nxf.log
giab/NA12878_illumina_hiseq_exome        | PASSED | 4829237=completed vip/feat_wes_wgs_config/test/output/giab/NA12878_illumina_hiseq_exome/.nxf.log
giab/NA12878_nanopore_bam                | PASSED | 4829238=completed vip/feat_wes_wgs_config/test/output/giab/NA12878_nanopore_bam/.nxf.log
gvcf/liftover                            | PASSED | 4829239=completed vip/feat_wes_wgs_config/test/output/gvcf/liftover/.nxf.log
gvcf/multiproject                        | PASSED | 4829240=completed vip/feat_wes_wgs_config/test/output/gvcf/multiproject/.nxf.log
gvcf/trio                                | PASSED | 4829241=completed vip/feat_wes_wgs_config/test/output/gvcf/trio/.nxf.log
vcf/aip                                  | PASSED | 4829242=completed vip/feat_wes_wgs_config/test/output/vcf/aip/.nxf.log
vcf/chd7                                 | PASSED | 4829243=completed vip/feat_wes_wgs_config/test/output/vcf/chd7/.nxf.log
vcf/corner_cases                         | PASSED | 4829244=completed vip/feat_wes_wgs_config/test/output/vcf/corner_cases/.nxf.log
vcf/deb_register                         | PASSED | 4829245=completed vip/feat_wes_wgs_config/test/output/vcf/deb_register/.nxf.log
vcf/empty_input                          | PASSED | 4829246=completed vip/feat_wes_wgs_config/test/output/vcf/empty_input/.nxf.log
vcf/empty_output_filter_samples          | PASSED | 4829247=completed vip/feat_wes_wgs_config/test/output/vcf/empty_output_filter_samples/.nxf.log
vcf/empty_output_filter                  | PASSED | 4829248=completed vip/feat_wes_wgs_config/test/output/vcf/empty_output_filter/.nxf.log
vcf/filter_samples                       | PASSED | 4829249=completed vip/feat_wes_wgs_config/test/output/vcf/filter_samples/.nxf.log
vcf/jvar_blb                             | PASSED | 4829250=completed vip/feat_wes_wgs_config/test/output/vcf/jvar_blb/.nxf.log
vcf/jvar_plp                             | PASSED | 4829251=completed vip/feat_wes_wgs_config/test/output/vcf/jvar_plp/.nxf.log
vcf/liftover                             | PASSED | 4829252=completed vip/feat_wes_wgs_config/test/output/vcf/liftover/.nxf.log
vcf/mtdna_blb                            | PASSED | 4829253=completed vip/feat_wes_wgs_config/test/output/vcf/mtdna_blb/.nxf.log
vcf/mtdna_plp                            | PASSED | 4829254=completed vip/feat_wes_wgs_config/test/output/vcf/mtdna_plp/.nxf.log
vcf/multiproject_classify                | PASSED | 4829255=completed vip/feat_wes_wgs_config/test/output/vcf/multiproject_classify/.nxf.log
vcf/mvid                                 | PASSED | 4829256=completed vip/feat_wes_wgs_config/test/output/vcf/mvid/.nxf.log
vcf/no_spliceai                          | PASSED | 4829257=completed vip/feat_wes_wgs_config/test/output/vcf/no_spliceai/.nxf.log
vcf/str                                  | PASSED | 4829258=completed vip/feat_wes_wgs_config/test/output/vcf/str/.nxf.log
vcf/trio                                 | PASSED | 4829259=completed vip/feat_wes_wgs_config/test/output/vcf/trio/.nxf.log
vcf/vkgl_lb                              | PASSED | 4829260=completed vip/feat_wes_wgs_config/test/output/vcf/vkgl_lb/.nxf.log
vcf/vkgl_lp                              | PASSED | 4829261=completed vip/feat_wes_wgs_config/test/output/vcf/vkgl_lp/.nxf.log
vcf/vkgl_vus                             | PASSED | 4829262=completed vip/feat_wes_wgs_config/test/output/vcf/vkgl_vus/.nxf.log
```